### PR TITLE
Use poe-utils to slice Incursion room icons and convert images

### DIFF
--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1543,7 +1543,7 @@ class BaseParser:
         if not parsed_args.convert_images:
             return
 
-        os.system('magick convert "%s" "%s"' % (
+        os.system('process-image convert "%s" "%s"' % (
             out_path, out_path.replace('.dds', '.png'),
         ))
         os.remove(out_path)

--- a/PyPoE/cli/exporter/wiki/parsers/incursion.py
+++ b/PyPoE/cli/exporter/wiki/parsers/incursion.py
@@ -260,8 +260,8 @@ class IncursionRoomParser(parser.BaseParser):
                     idl_sources.add(src)
 
                 os.system(
-                    'magick "%(src)s" -crop %(w)sx%(h)s+%(x)s+%(y)s '
-                    '"%(dst)s incursion room icon.png"' %
+                    'process-image convert "%(src)s" "%(dst)s incursion room icon.png" '
+                    '%(x)s %(y)s %(w)s %(h)s' %
                     {
                         'src': src,
                         'dst': os.path.join(self._img_path, data['icon']),


### PR DESCRIPTION
The game uses BC7 texture compression for some image files, which is something that ImageMagick doesn't support.

This changes all uses of ImageMagick for conversion into analogous calls to `poe-utils`' `process-image`, which wiki exporters need to download and put into the runtime path.

The tool can convert BC1/BC2/BC3/BC7 and several uncompressed pixel formats to RGB/RGBA PNG files, optionally cropping the image.