### PR TITLE
Make RelationalReader consistent for non-English languages

### DIFF
--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -992,15 +992,17 @@ class RelationalReader(AbstractFileCache):
 
     def __getitem__(self, item):
         """
-        Shortcut that also appends Data/ if missing
+        Shortcut that prepends Data/{language} if missing and transforms plain
+        Data/ prefixes into language-specific prefixes.
 
         The following calls are equivalent:
 
-        * self['DF.dat'] <==> read_file('Data/DF.dat').reader
-        * self['Data/DF.dat'] <==> read_file('Data/DF.dat').reader
+        * self['DF.dat'] <==> read_file('Data/{language}DF.dat').reader
+        * self['Data/DF.dat'] <==> read_file('Data/{language}DF.dat').reader
         """
-        if not item.startswith('Data/'):
-            item = 'Data/' + self._language + item
+        if item.startswith('Data/'):
+            item = item[len('Data/'):]
+        item = 'Data/' + self._language + item
 
         return self.get_file(item).reader
 


### PR DESCRIPTION
RelationalReader's `get_file` strips away the language-specific directory prefix from DAT files when resolving them. This prefix is `Data/` for English and `Data/{language}/` for the rest.
The `[]` shortcut (`__get_item__`) unconditionally transforms `X.dat` and `Data/X.dat` into `Data/X.dat` which fails to strip anything in `get_file` when language is non-English.

This change alters the behaviour of the shortcut so that it transforms both forms of input into `Data/{language}/X.dat` so that the lookup will store the data file under the correct base filename.