### PR TITLE
Turn \n in quality descriptions into <br>

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -543,10 +543,10 @@ class SkillParserShared(parser.BaseParser):
                         values.append(
                             row['StatsValuesPermille'][index] / 1000
                         )
-                lines.append(ts.format_string(
+                lines.extend(ts.format_string(
                     values=values,
                     is_range=[False, ] * len(values),
-                )[0])
+                )[0].split('\n'))
 
             infobox[prefix + 'stat_text'] = '<br>'.join(lines)
 


### PR DESCRIPTION
The code for joining multiple lines using \<br> was already there, just
the split was missing.

```
$ diff old_skill_SpectralHelix.txt fixed_skill_SpectralHelix.txt 
17,18c17
< |quality_type3_stat_text                 = Bounces up to 0.1 times
< Modifiers to number of Projectiles instead apply to the number of Bounces
---
> |quality_type3_stat_text                 = Bounces up to 0.1 times<br>Modifiers to number of Projectiles instead apply to the number of Bounces
```

fixes #10 