### PR TITLE
turn relative paths for out_dir and tmp_dir into absolute paths

### DIFF
--- a/PyPoE/cli/exporter/wiki/core.py
+++ b/PyPoE/cli/exporter/wiki/core.py
@@ -52,8 +52,8 @@ __all__ = ['WikiHandler']
 class WikiHandler(BaseHandler):
     def __init__(self, sub_parser):
         # Config Options
-        config.add_option('temp_dir', 'is_directory(exists=True)')
-        config.add_option('out_dir', 'is_directory(exists=True)')
+        config.add_option('temp_dir', 'is_directory(exists=True, make_absolute=True)')
+        config.add_option('out_dir', 'is_directory(exists=True, make_absolute=True)')
         config.register_setup('temp_dir', self._setup)
         config.add_setup_variable('temp_dir', 'hash', 'string(default="")')
         config.add_setup_listener('version', self._ver_dist_changed)

--- a/PyPoE/shared/config/validator.py
+++ b/PyPoE/shared/config/validator.py
@@ -214,7 +214,7 @@ def is_file(value, *args, exists=True, allow_empty=False, **kwargs):
         return value
 
 
-def is_directory(value, *args, exists=True, allow_empty=False, **kwargs):
+def is_directory(value, *args, exists=True, allow_empty=False, make_absolute=False, **kwargs):
     """
     Checks whether the value is a valid directory path (and optionally whether
     it exists).
@@ -227,6 +227,8 @@ def is_directory(value, *args, exists=True, allow_empty=False, **kwargs):
         whether the directory is required to exist to pass the validation check
     allow_empty : bool
         whether empty strings are allowed
+    make_absolute : bool
+        whether to turn a potentional relative path into an absolute one
 
     Returns
     -------
@@ -244,6 +246,8 @@ def is_directory(value, *args, exists=True, allow_empty=False, **kwargs):
         _exists(value, exists)
         if not os.path.isdir(value):
             raise ValidateError('"%s" is not a directory.' % value)
+        if make_absolute:
+            value = os.path.abspath(value)
         return value
 
 # =============================================================================


### PR DESCRIPTION
two blemishs:
 - the translation from relative to absolute path happens in
   'is_directory' which may be confusing/unexpect. Might be able to do
   it with an extra listener? Unsure where to put that one
 - upon setting a value with relative path it still outputs the old
   relative value, even thought it sets the absolute one. Fetching the
   new one is problematic incase the variable requires setup.

Fixes #14


```
turmfalke@Industria ~/PyPoE_work $ pypoe_exporter config set out_dir ./out
22:46:23 Config setting "out_dir" has been set to:
./out
turmfalke@Industria ~/PyPoE_work $ pypoe_exporter config get out_dir
22:46:27 Config setting "out_dir" is currently set to:
/home/turmfalke/PyPoE_work/out
```
