### PR TITLE
CHORE: Add Devcontainer configuration, CLI dockerfile

### DIFF
--- a/.devcontainer/.prettierignore
+++ b/.devcontainer/.prettierignore
@@ -1,0 +1,1 @@
+devcontainer.json

--- a/.devcontainer/.prettierignore
+++ b/.devcontainer/.prettierignore
@@ -1,1 +1,0 @@
-devcontainer.json

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT="3.9-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+# RUN apt-get update\
+#     && apt-get install cmake \
+#     && git clone https://github.com/zao/ooz.git\
+#     && cd ooz\
+#     && cmake --build .

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,15 +1,27 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/python-3/.devcontainer/base.Dockerfile
 
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT="3.9-bullseye"
+ARG VARIANT="3-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/
 # RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
 #    && rm -rf /tmp/pip-tmp
+RUN apt-get update\
+    && apt-get install -y cmake libsodium-dev libunistring-dev \
+    && cd /tmp/\
+    && git clone https://github.com/zao/ooz.git\
+    && cd ooz/\
+    && cmake .\
+    && cmake --build .\
+    && cp ooz /usr/local/bin\
+    && cd /\
+    && rm -rf /tmp/ooz/\
+    && apt-get -y purge cmake libsodium-dev libunistring-dev\
+    && apt-get -y autoremove\
+    && apt-get -y autoclean
+
+# Re-add if UI work needs to be done
 # RUN apt-get update\
-#     && apt-get install cmake \
-#     && git clone https://github.com/zao/ooz.git\
-#     && cd ooz\
-#     && cmake --build .
+#     && apt-get install -y python-pyside

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,5 +23,5 @@ RUN apt-get update\
     && apt-get -y autoclean
 
 # Re-add if UI work needs to be done
-# RUN apt-get update\
-#     && apt-get install -y python-pyside
+RUN apt-get update\
+    && apt-get install -y imagemagick

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,57 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/python-3
+{
+  "name": "Python 3",
+  "runArgs": ["--init"],
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      // Update 'VARIANT' to pick a Python version: 3, 3.9, 3.8, 3.7, 3.6.
+      // Append -bullseye or -buster to pin to an OS version.
+      // Use -bullseye variants on local on arm64/Apple Silicon.
+      "VARIANT": "3-bullseye",
+      // Options
+      "NODE_VERSION": "none"
+    }
+  },
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.languageServer": "Pylance",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+    "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+    "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+    "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+    "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+    "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+    "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+    "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+    "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "mikestead.dotenv",
+    "editorconfig.editorconfig",
+    "mutantdino.resourcemonitor"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "git": "os-provided",
+    "desktop-lite": "latest"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
     }
   },
   "mounts": [
+    // prettier-ignore
     "type=bind,source=C:\\Program\ Files\ (x86)\\Steam\\steamapps\\common\\Path\ of\ Exile,target=/poe,readonly"
   ],
 
@@ -42,7 +43,8 @@
     "ms-python.vscode-pylance",
     "mikestead.dotenv",
     "editorconfig.editorconfig",
-    "mutantdino.resourcemonitor"
+    "mutantdino.resourcemonitor",
+    "github.vscode-pull-request-github"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/python-3
 {
-  "name": "Python 3",
+  "name": "PyPoE",
   "runArgs": ["--init"],
   "build": {
     "dockerfile": "Dockerfile",
@@ -17,7 +17,8 @@
   },
   "mounts": [
     // prettier-ignore
-    "type=bind,source=C:\\Program\ Files\ (x86)\\Steam\\steamapps\\common\\Path\ of\ Exile,target=/poe,readonly"
+    "type=bind,source=${localEnv:POE_INSTALL_PATH},target=/poe,readonly"
+    // "type=bind,source=C:\\Program Files (x86)\\Steam\\steamapps\\common\\Path of Exile,target=/poe,readonly"
   ],
 
   // Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,6 @@
     }
   },
   "mounts": [
-    // prettier-ignore
     "type=bind,source=${localEnv:POE_INSTALL_PATH},target=/poe,readonly"
     // "type=bind,source=C:\\Program Files (x86)\\Steam\\steamapps\\common\\Path of Exile,target=/poe,readonly"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,9 @@
       "NODE_VERSION": "none"
     }
   },
+  "mounts": [
+    "type=bind,source=C:\\Program\ Files\ (x86)\\Steam\\steamapps\\common\\Path\ of\ Exile,target=/poe,readonly"
+  ],
 
   // Set *default* container specific settings.json values on container create.
   "settings": {
@@ -46,7 +49,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "pip3 install --user -r requirements.txt",
+  "postCreateCommand": ".devcontainer/postCreateCommand.sh",
 
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+pip install --user -U pip setuptools
+pip install --user -U -r test_requirements.txt
+pip install --user -U -e .[full]
+pypoe_exporter config set out_dir ./out
+mkdir /tmp/pypoe-temp
+pypoe_exporter config set temp_dir /tmp/pypoe-temp
+pypoe_exporter config set ggpk_path /poe
+pypoe_exporter setup perform

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.devcontainer
+.vscode
+PyPoE.egg-info

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[Dockerfile]
+tab_width = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+ARG PYTHON_VERSION=3.9
+FROM python:${PYTHON_VERSION}-bullseye
+
+### Install ooz from Zao
+RUN export DEBIAN_FRONTEND=noninteractive\
+    && apt-get update\
+    && apt-get install -y cmake libsodium-dev libunistring-dev\
+    && cd /tmp/\
+    && git clone https://github.com/zao/ooz.git\
+    && cd ooz/\
+    && cmake .\
+    && cmake --build .\
+    && cp ooz /usr/local/bin\
+    && cd /\
+    && rm -rf /tmp/ooz/\
+    && apt-get -y purge cmake libsodium-dev libunistring-dev\
+    && apt-get -y autoremove\
+    && apt-get -y autoclean
+
+### Install imagemagick for image manipulation
+RUN export DEBIAN_FRONTEND=noninteractive\
+    && apt-get update\
+    && apt-get install -y imagemagick
+
+### Install pypoe
+ARG PYPOE_TAG=dev
+COPY . /tmp/pypoe
+RUN cd /tmp/pypoe\
+    && pip install -U pip setuptools\
+    && pip install -U -r test_requirements.txt\
+    && pip install -U -e .[full]\
+    && cd /\
+    && rm -rf /tmp/pypoe\
+    && mkdir /output\
+    && pypoe_exporter config set out_dir /output\
+    && mkdir /tmp/pypoe-temp\
+    && pypoe_exporter config set temp_dir /tmp/pypoe-temp\
+    && pypoe_exporter config set ggpk_path /poe-data\
+    && pypoe_exporter setup perform
+
+VOLUME [ "/output" ]
+
+ENTRYPOINT [ "pypoe_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,20 +24,22 @@ RUN export DEBIAN_FRONTEND=noninteractive\
 
 ### Install pypoe
 ARG PYPOE_TAG=dev
-COPY . /tmp/pypoe
-RUN cd /tmp/pypoe\
+COPY . /pypoe
+WORKDIR /pypoe
+RUN pip install --upgrade pip\
     && pip install -U pip setuptools\
     && pip install -U -r test_requirements.txt\
-    && pip install -U -e .[full]\
-    && cd /\
-    && rm -rf /tmp/pypoe\
+    && pip install -U -e .[cli]\
     && mkdir /output\
     && pypoe_exporter config set out_dir /output\
     && mkdir /tmp/pypoe-temp\
     && pypoe_exporter config set temp_dir /tmp/pypoe-temp\
+    && mkdir /poe-data\
     && pypoe_exporter config set ggpk_path /poe-data\
     && pypoe_exporter setup perform
 
-VOLUME [ "/output" ]
+WORKDIR /output
+
+VOLUME [ "/poe-data", "/output" ]
 
 ENTRYPOINT [ "pypoe_exporter" ]


### PR DESCRIPTION
# Abstract

Adds docker support in 2 ways. Set up the required config for a vscode/codespaces devcontainer (see `.devcontainer` for details). Set up a dockerfile exposing the compiled `pypoe_exporter` command.

# Action Taken

- Added development `Dockerfile` and `devcontainer.json` config.
- Added a `Dockerfile` exposing the pypoe_exporter command for running the tool without setting up a full Python environment.

# Caveats

For the devcontainer - A note will need to be added to the wiki installation page as the devcontainer does require an environment variable be set to mount the local PoE install location.

I'm torn on the utility of the CLI docker image, is it any easier to use docker to run the exporter vs setting up python? If this is desirable, probably worth setting up an action to automatically build the docker image and push it to docker hub.