### PR TITLE
Fix the Scourge Map Series export

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -573,7 +573,7 @@ class ItemsParser(SkillParserShared):
         'Ritual': '3.13.0',
         'Ultimatum': '3.14.0',
         'Expedition': '3.15.0',
-        'Scourge': '3.16.0'
+        'Hellscape': '3.16.0', #AKA Scourge
     }
 
     _IGNORE_DROP_LEVEL_CLASSES = (

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -14396,6 +14396,18 @@ specification = Specification({
                 name='HeistTier',
                 type='int',
             ),
+            Field(
+                name='RitualTier',
+                type='int',
+            ),
+            Field(
+                name='ExpeditionTier',
+                type='int',
+            ),
+            Field(
+                name='HellscapeTier', #AKA Scourge
+                type='int',
+            ),
         ),
     ),
     'MapStatConditions.dat': File(


### PR DESCRIPTION
# Abstract

This makes some updates so the map exports can work.

# Action Taken

I updated the MapSeriesTiers.dat spec, and the enum of map release versions so that the Scourge map series can be exported.
At a glance, Ritual and Expedition map series exports look okay as well.

# Caveats

- It could be nice to have Scourge in the enum, and rework some code to allow for mapping between Scourge and Hellscape (the name vs the ID of the map series), but I took this simpler approach for now.
- In this PR, and in all my others up to this point, I have not changed or tested image exports.
- This may be dependent on changes from #38 in some way. I tested these changes on top of those, but I didn't want all of the changes from #38 in the commits for this PR.

# FAO

@pm5k @acbeaumo @Journeytojah
