### PR TITLE
Fix Crafting Bench Export for 3.16

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -1359,24 +1359,6 @@ class MonsterParser(GenericLuaParser):
 
 
 class CraftingBenchParser(GenericLuaParser):
-
-    # 3.15
-    # This is a hack and should be properly parsed, but it works for now.
-    # TODO: bring CraftingBenchSortCategory.dat in and parse the affixes from it
-
-    def SortCategoryHelper(d):
-        affix_types = [
-            'CannotBeGenerated',
-            'Prefix',
-            'Suffix',
-            'Other',
-            'Enchant',
-            'Undiscovered',
-            'Veiled'
-        ]
-        # print('yep', sort[d])
-        return affix_types[d]
-
     _DATA = (
         ('HideoutNPCsKey', {
             'key': 'npc',
@@ -1388,7 +1370,7 @@ class CraftingBenchParser(GenericLuaParser):
         ('Order', {
             'key': 'ordinal',
         }),
-        ('ModsKey', {
+        ('AddMod', {
             'key': 'mod_id',
             'value': lambda v: v['Id'],
         }),
@@ -1399,12 +1381,12 @@ class CraftingBenchParser(GenericLuaParser):
         ('Name', {
             'key': 'name',
         }),
-        ('ItemClassesKeys', {
+        ('ItemClasses', {
             'key': 'item_classes',
             'value': lambda v: [k['Name'] for k in v],
             'default': [],
         }),
-        ('ItemClassesKeys', {
+        ('ItemClasses', {
             'key': 'item_classes_ids',
             'value': lambda v: [k['Id'] for k in v],
             'default': [],
@@ -1435,7 +1417,7 @@ class CraftingBenchParser(GenericLuaParser):
         #     'key': 'mod_group',
         #     'default': '',
         # }),
-        ('CraftingItemClassCategoriesKeys', {
+        ('CraftingItemClassCategories', {
             'key': 'crafting_item_class_categories',
             'value': lambda v: [k['Text'] for k in v],
         }),
@@ -1453,8 +1435,7 @@ class CraftingBenchParser(GenericLuaParser):
         }),
         ('SortCategory', {
             'key': 'affix_type',
-            'value': SortCategoryHelper,
-            # lambda v: v['SortCategoryKey']['Id'],
+            'value': lambda v: v['Id'],
         }),
     )
 
@@ -1470,7 +1451,7 @@ class CraftingBenchParser(GenericLuaParser):
                 row, self._DATA, data['crafting_bench_options'])
             data['crafting_bench_options'][-1]['id'] = row.rowid
 
-            for i, base_item in enumerate(row['Cost_BaseItemTypesKeys']):
+            for i, base_item in enumerate(row['Cost_BaseItemTypes']):
                 data['crafting_bench_options_costs'].append(OrderedDict((
                     ('option_id', row.rowid),
                     ('name', base_item['Name']),

--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -1359,6 +1359,27 @@ class MonsterParser(GenericLuaParser):
 
 
 class CraftingBenchParser(GenericLuaParser):
+    def RecipeLocationGenerator(val):
+        text_descriptions = []
+        areas = []
+        for key in val:
+            if len(key['UnlockDescription']) > 0:
+                text_descriptions.append(key['UnlockDescription'])
+            # Default to the text description instead of the more ambiguous zone name.
+            # This defaulting is useful for disambiguating the different Aspirant's Trial zones
+            if len(key['UnlockArea']['Name']) > 0 and len(text_descriptions) == 0:
+                areas.append(key['UnlockArea']['Name'])
+        return ' • '.join(text_descriptions + areas)
+        
+    def DetermineModifier(val):
+        # AddMod value
+        if(not val[0] is None and len(val[0]) > 0):
+            return val[0]['Id']
+        # AddEnchantment value
+        elif (not val[1] is None and len(val[1]) > 0):
+            return val[1]['Id']
+        return None
+
     _DATA = (
         ('HideoutNPCsKey', {
             'key': 'npc',
@@ -1370,9 +1391,9 @@ class CraftingBenchParser(GenericLuaParser):
         ('Order', {
             'key': 'ordinal',
         }),
-        ('AddMod', {
+        ('AddModOrEnchantment', {
             'key': 'mod_id',
-            'value': lambda v: v['Id'],
+            'value': DetermineModifier,
         }),
         ('RequiredLevel', {
             'key': 'required_level',
@@ -1407,7 +1428,7 @@ class CraftingBenchParser(GenericLuaParser):
         }),
         ('RecipeIds', {
             'key': 'recipe_unlock_location',
-            'value': lambda v: '<br>'.join([k['UnlockDescription'] for k in v]),
+            'value': RecipeLocationGenerator,
             'default': '',
         }),
         ('Tier', {

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -5256,6 +5256,10 @@ specification = Specification({
                 fields=('Cost_BaseItemTypes', 'Cost_Values'),
                 zip=True,
             ),
+            VirtualField(
+                name='AddModOrEnchantment',
+                fields=('AddMod','AddEnchantment'),
+            )
         ),
     ),
     'CraftingBenchSortCategories.dat': File(
@@ -19886,8 +19890,9 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Key0',
+                name='UnlockArea',
                 type='ulong',
+                key='WorldAreas.dat',
             ),
         ),
     ),


### PR DESCRIPTION
```
DELETE THIS TEXT BOX BEFORE SUBMITTING THE PR.

When filling in the template, please delete the "filler" paragraph below the `# Header` 
portion and replace it with what the paragraph is asking from you. 
Keep these PR's nice and tidy and spend the time to write it out
properly. We will reject PR's that do not follow or fill in this template properly.
```

# Abstract

I made updates so the crafting bench export will work with our 3.16 code base and the 3.16 ggpk.

# Action Taken

Update CraftingBenchParser _DATA definitions to match the spec.
Remove old hacky translation for sort category since it properly parses the .dat file now.
Update the Cost_BaseItemTypes column reference to match changed name in spec.
This fixes #41

# Caveats

This does not fix issue #24.
This works independently of the other PRs and changes.

# FAO
@pm5k @Journeytojah @acbeaumo
