### PR TITLE
Passives Export - Remove Royale Passives and Flag Atlas Passives

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -230,6 +230,13 @@ class PassiveSkillParser(parser.BaseParser):
 
         passives = self._apply_filter(parsed_args, passives)
 
+        console('Found %s passives. Removing Royale passives...' % len(passives))
+        passives = [
+            passive for passive in passives
+            if not passive['Id'].startswith('royale')
+        ]
+        console('%s passives left for processing.' % len(passives))
+
         if not passives:
             console(
                 'No passives found for the specified parameters. Quitting.',
@@ -314,7 +321,7 @@ class PassiveSkillParser(parser.BaseParser):
 
             data['stat_text'] = '<br>'.join(self._get_stats(
                 stat_ids, values,
-                translation_file='passive_skill_stat_descriptions.txt'
+                translation_file=self.get_translation_file(passive['Id'])
             ))
 
             # For now this is being added to the stat text
@@ -377,6 +384,12 @@ class PassiveSkillParser(parser.BaseParser):
             )
 
         return r
+    
+    def get_translation_file(self, passive_id: str):
+        if passive_id.startswith('atlas'):
+            return 'atlas_stat_descriptions.txt'
+        else:
+            return 'passive_skill_stat_descriptions.txt'
 
 # =============================================================================
 # Functions

--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -230,12 +230,12 @@ class PassiveSkillParser(parser.BaseParser):
 
         passives = self._apply_filter(parsed_args, passives)
 
-        console('Found %s passives. Removing Royale passives...' % len(passives))
+        console(f'Found {len(passives)} passives. Removing Royale passives...')
         passives = [
             passive for passive in passives
             if not passive['Id'].startswith('royale')
         ]
-        console('%s passives left for processing.' % len(passives))
+        console(f'{len(passives)} passives left for processing.')
 
         if not passives:
             console(


### PR DESCRIPTION
# Abstract

I updated the passives export so it excludes Royale-specific passives.
It also flags Atlas Passives to support easier filtering in queries.

# Action Taken

I'm excluding Royale passives by excluding all passives whose Ids start with "royale".
I'm flagging all passives whose Ids start with "atlas" as atlas passives. This flag becomes part of the `Passive skill` template markup that gets generated, as the parameter `is_atlas_passive`.
These string comparisons are somewhat fragile, but I didn't see a flag in the .dat or a better way to do it.

We could exclude things with certain root nodes, but this does not seem worth the effort of parsing the skill trees.
String prefixes are easy enough to identify and maintain.

# Caveats

[The passive skills module](https://www.poewiki.net/wiki/Module:Passive_skill) still needs to be updated to handle the new `is_atlas_passive` parameter. It should get a boolean field in the cargo table definition with the same name.

# FAO

@pm5k @Journeytojah
