### PR TITLE
Patches masteries

### DIFF
--- a/PyPoE/cli/exporter/wiki/handler.py
+++ b/PyPoE/cli/exporter/wiki/handler.py
@@ -347,24 +347,29 @@ class ExporterHandler(BaseHandler):
 
         """
         # By id
-        a_id = sub_parser.add_parser(
-            'id',
-            help='Extract via a list of internal ids.'
-        )
-        self.add_default_parsers(
-            parser=a_id,
-            cls=cls,
-            func=cls.by_id,
-            *args,
-            **kwargs
-        )
-        a_id.add_argument(
-            'id',
-            help='Internal id. Can be specified multiple times.',
-            nargs='+',
-        )
+        self.add_id_subparser_filters(sub_parser, cls, *args, **kwargs)
 
         # by name
+        self.add_name_subparser_filters(sub_parser, cls, *args, **kwargs)
+
+        # by row ID
+        self.add_rowid_subparser_filters(sub_parser, cls, *args, **kwargs)
+    
+    def add_name_subparser_filters(self, sub_parser, cls, *args, **kwargs):
+        """
+        Adds default sub parsers for id, name and rowid.
+
+        Parameters
+        ----------
+        sub_parser
+        cls: object
+            Expected to have the methods:
+            by_name  - handling for name based searching
+
+        Returns
+        -------
+
+        """
         a_name = sub_parser.add_parser(
             'name',
             help='Extract via a list of names.'
@@ -383,7 +388,21 @@ class ExporterHandler(BaseHandler):
             nargs='+',
         )
 
-        # by row ID
+    def add_rowid_subparser_filters(self, sub_parser, cls, *args, **kwargs):
+        """
+        Adds default sub parsers for id, name and rowid.
+
+        Parameters
+        ----------
+        sub_parser
+        cls: object
+            Expected to have the methods:
+            by_rowid - handling for rowid based searching
+
+        Returns
+        -------
+
+        """
         a_rid = sub_parser.add_parser(
             'rowid',
             help='Extract via rowid in the primary dat file.'
@@ -408,6 +427,39 @@ class ExporterHandler(BaseHandler):
             help='Ending index',
             type=int,
         )
+        
+    def add_id_subparser_filters(self, sub_parser, cls, *args, **kwargs):
+        """
+        Adds default sub parsers for id, name and rowid.
+
+        Parameters
+        ----------
+        sub_parser
+        cls: object
+            Expected to have the methods:
+            by_id    - handling for id based searching
+
+        Returns
+        -------
+
+        """
+        a_id = sub_parser.add_parser(
+            'id',
+            help='Extract via a list of internal ids.'
+        )
+        self.add_default_parsers(
+            parser=a_id,
+            cls=cls,
+            func=cls.by_id,
+            *args,
+            **kwargs
+        )
+        a_id.add_argument(
+            'id',
+            help='Internal id. Can be specified multiple times.',
+            nargs='+',
+        )
+
 
     def add_default_parsers(self, parser, cls, func=None, handler=None,
                             wiki=True, wiki_handler=None):

--- a/PyPoE/cli/exporter/wiki/parsers/masteries.py
+++ b/PyPoE/cli/exporter/wiki/parsers/masteries.py
@@ -67,7 +67,7 @@ class EffectWikiCondition(parser.WikiCondition):
         'main_page',
     )
 
-    NAME = 'Mastery Effect' # Seems to be the wiki template that will get called
+    NAME = 'Mastery effect' # Seems to be the wiki template that will get called
     ADD_INCLUDE = False
     INDENT = 36
 
@@ -76,7 +76,7 @@ class GroupWikiCondition(parser.WikiCondition):
         'main_page',
     )
 
-    NAME = 'Mastery Group' # Seems to be the wiki template that will get called
+    NAME = 'Mastery group' # Seems to be the wiki template that will get called
     ADD_INCLUDE = False
     INDENT = 36
 
@@ -96,7 +96,7 @@ class MasteryCommandHandler(ExporterHandler):
             'effects',
             help='Mastery exporter for mastery effects (i.e. the bonus you can actually pick)',
         )
-        mastery_eff_parser.set_defaults(func=lambda args: parser.print_help())
+        mastery_eff_parser.set_defaults(func=lambda args: mastery_eff_parser.print_help())
         mastery_eff_sub = mastery_eff_parser.add_subparsers()
 
         self.add_default_subparser_filters(
@@ -109,7 +109,7 @@ class MasteryCommandHandler(ExporterHandler):
             'groups',
             help='Mastery exporter for mastery groups',
         )
-        mastery_grp_parser.set_defaults(func=lambda args: parser.print_help())
+        mastery_grp_parser.set_defaults(func=lambda args: mastery_grp_parser.print_help())
         mastery_grp_sub = mastery_grp_parser.add_subparsers()
 
         self.add_default_subparser_filters(
@@ -238,7 +238,7 @@ class MasteryEffectParser(parser.BaseParser):
                 stat_ids.append(stat['Id'])
                 data[f'stat{one_based_stat_index}_id'] = stat['Id']
                 values.append(mastery[f'Stat{one_based_stat_index}Value'])
-                data['stat{one_based_stat_index}_value'] = mastery[f'Stat{one_based_stat_index}Value']
+                data[f'stat{one_based_stat_index}_value'] = mastery[f'Stat{one_based_stat_index}Value']
 
             data['stat_text'] = '<br>'.join(self._get_stats(
                 stat_ids, values,

--- a/PyPoE/cli/exporter/wiki/parsers/masteries.py
+++ b/PyPoE/cli/exporter/wiki/parsers/masteries.py
@@ -1,0 +1,275 @@
+"""
+Overview
+===============================================================================
+
++----------+------------------------------------------------------------------+
+| Path     | PyPoE/cli/exporter/wiki/parsers/masteries.py                     |
++----------+------------------------------------------------------------------+
+| Version  | 1.0.0a0                                                          |
++----------+------------------------------------------------------------------+
+| Revision | $Id$                  |
++----------+------------------------------------------------------------------+
+| Author   | angelic_knight                                                   |
++----------+------------------------------------------------------------------+
+
+Description
+===============================================================================
+
+
+
+Agreement
+===============================================================================
+
+See PyPoE/LICENSE
+
+Documentation
+===============================================================================
+
+Public API
+-------------------------------------------------------------------------------
+
+Internal API
+-------------------------------------------------------------------------------
+"""
+
+# =============================================================================
+# Imports
+# =============================================================================
+
+# Python
+import re
+import os.path
+import warnings
+from functools import partialmethod
+from collections import OrderedDict
+
+# 3rd-party
+
+# self
+from PyPoE.cli.core import console, Msg
+from PyPoE.cli.exporter.wiki import parser
+from PyPoE.cli.exporter.wiki.handler import ExporterHandler, ExporterResult
+from PyPoE.poe.file.psg import PSGFile
+
+# =============================================================================
+# Globals
+# =============================================================================
+
+__all__ = []
+
+# =============================================================================
+# Classes
+# =============================================================================
+
+
+class WikiCondition(parser.WikiCondition):
+    COPY_KEYS = (
+        'main_page',
+    )
+
+    NAME = 'Mastery'
+    ADD_INCLUDE = False
+    INDENT = 36
+
+
+class MasteryCommandHandler(ExporterHandler):
+    def __init__(self, sub_parser):
+        self.parser = sub_parser.add_parser(
+            'mastery',
+            help='Mastery exporter',
+        )
+        self.parser.set_defaults(func=lambda args: self.parser.print_help())
+
+        self.add_default_subparser_filters(
+            sub_parser=self.parser.add_subparsers(),
+            cls=MasterySkillParser,
+        )
+
+        # filtering
+        '''a_filter = sub.add_parser(
+            'filter',
+            help='Extract passives using filters.'
+        )
+        self.add_default_parsers(
+            parser=a_filter,
+            cls=PassiveSkillParser,
+            func=PassiveSkillParser.by_filter,
+        )
+
+        a_filter.add_argument(
+            '-ft-id', '--filter-id', '--filter-metadata-id',
+            help='Regular expression on the id',
+            type=str,
+            dest='re_id',
+        )'''
+
+    def add_default_parsers(self, *args, **kwargs):
+        super().add_default_parsers(*args, **kwargs)
+        self.add_format_argument(kwargs['parser'])
+        self.add_image_arguments(kwargs['parser'])
+        kwargs['parser'].add_argument(
+            '-ft-id', '--filter-id', '--filter-metadata-id',
+            help='Regular expression on the id',
+            type=str,
+            dest='re_id',
+        )
+
+
+class MasterySkillParser(parser.BaseParser):
+    _MASTERY_FILE_NAME = 'PassiveSkillMasteryEffects.dat'
+    _files = [
+        _MASTERY_FILE_NAME,
+    ]
+
+    _passive_column_index_filter = partialmethod(
+        parser.BaseParser._column_index_filter,
+        dat_file_name=_MASTERY_FILE_NAME,
+        error_msg='Several masteries have not been found:\n%s',
+    )
+
+    _MAX_STAT_ID = 3 # How many stats each one can have.
+
+    _COPY_KEYS = OrderedDict((
+        ('Id', {
+            'template': 'id',
+        }),
+    ))
+
+    def _apply_filter(self, parsed_args, masteries):
+        if parsed_args.re_id:
+            parsed_args.re_id = re.compile(parsed_args.re_id, flags=re.UNICODE)
+        else:
+            return masteries
+
+        new = []
+
+        for mastery in masteries:
+            if parsed_args.re_id and not \
+                    parsed_args.re_id.match(mastery['Id']):
+                continue
+
+            new.append(mastery)
+
+        return new
+
+    def by_rowid(self, parsed_args):
+        return self.export(
+            parsed_args,
+            self.rr[self._MASTERY_FILE_NAME][parsed_args.start:parsed_args.end],
+        )
+
+    def by_id(self, parsed_args):
+        return self.export(parsed_args, self._passive_column_index_filter(
+            column_id='Id', arg_list=parsed_args.id
+        ))
+
+    def by_name(self, parsed_args):
+        return self.export(parsed_args, self._passive_column_index_filter(
+            column_id='Name', arg_list=parsed_args.name
+        ))
+
+    def export(self, parsed_args, masteries):
+        r = ExporterResult()
+
+        masteries = self._apply_filter(parsed_args, masteries)
+
+        if not masteries:
+            console(
+                'No passives found for the specified parameters. Quitting.',
+                msg=Msg.warning,
+            )
+            return r
+
+        console('Accessing additional data...')
+
+        self.rr[self._MASTERY_FILE_NAME]
+
+        #self._image_init(parsed_args)
+
+        console(f'Found {len(masteries)}, parsing...')
+
+        for mastery in masteries:
+            data = dict()
+
+            for row_key, copy_data in self._COPY_KEYS.items():
+                value = mastery[row_key]
+
+                condition = copy_data.get('condition')
+                if condition is not None and not condition(mastery):
+                    continue
+
+                # Skip default values to reduce size of template
+                if value == copy_data.get('default'):
+                    continue
+
+                fmt = copy_data.get('format')
+                if fmt:
+                    value = fmt(value)
+                data[copy_data['template']] = value
+
+            stat_ids = []
+            values = []
+
+            j = 0
+            for i in range(0, self._MAX_STAT_ID):
+                try:
+                    stat = mastery['StatsKeys'][i]
+                except IndexError:
+                    break
+                j = i + 1
+                stat_ids.append(stat['Id'])
+                data['stat%s_id' % j] = stat['Id']
+                values.append(mastery['Stat%sValue' % j])
+                data['stat%s_value' % j] = mastery['Stat%sValue' % j]
+
+            data['stat_text'] = '<br>'.join(self._get_stats(
+                stat_ids, values,
+                translation_file='passive_skill_stat_descriptions.txt' # this might be wrong
+            ))
+
+            # # For now this is being added to the stat text
+            # for ps_buff in mastery['PassiveSkillBuffsKeys']:
+            #     stat_ids = [stat['Id'] for stat in
+            #                 ps_buff['BuffDefinitionsKey']['StatsKeys']]
+            #     values = ps_buff['Buff_StatValues']
+            #     #if passive['Id'] == 'AscendancyChampion7':
+            #     #    index = stat_ids.index('damage_taken_+%_from_hits')
+            #     #    del stat_ids[index]
+            #     #    del values[index]
+            #     for i, (sid, val) in enumerate(zip(stat_ids, values)):
+            #         j += 1
+            #         data['stat%s_id' % j] = sid
+            #         data['stat%s_value' % j] = val
+
+            #     text = '<br>'.join(self._get_stats(
+            #         stat_ids, values,
+            #         translation_file='passive_skill_aura_stat_descriptions.txt'
+            #     ))
+
+            #     if data['stat_text']:
+            #         data['stat_text'] += '<br>' + text
+            #     else:
+            #         data['stat_text'] = text
+
+            cond = WikiCondition(
+                data=data,
+                cmdargs=parsed_args,
+            )
+
+            r.add_result(
+                text=cond,
+                out_file='mastery_%s.txt' % data['id'],
+                wiki_page=[
+                    {
+                        'page': 'Mastery:' + self._format_wiki_title(data['id']),
+                        'condition': cond,
+                    },
+                ],
+                wiki_message='Mastery updater',
+            )
+
+        return r
+
+# =============================================================================
+# Functions
+# =============================================================================

--- a/PyPoE/cli/exporter/wiki/parsers/masteries.py
+++ b/PyPoE/cli/exporter/wiki/parsers/masteries.py
@@ -14,7 +14,7 @@ Overview
 
 Description
 ===============================================================================
-
+Parses out masteries and mastery effects into formats that are useful for the wiki
 
 
 Agreement
@@ -62,46 +62,61 @@ __all__ = []
 # =============================================================================
 
 
-class WikiCondition(parser.WikiCondition):
+class EffectWikiCondition(parser.WikiCondition):
     COPY_KEYS = (
         'main_page',
     )
 
-    NAME = 'Mastery'
+    NAME = 'Mastery Effect' # Seems to be the wiki template that will get called
+    ADD_INCLUDE = False
+    INDENT = 36
+
+class GroupWikiCondition(parser.WikiCondition):
+    COPY_KEYS = (
+        'main_page',
+    )
+
+    NAME = 'Mastery Group' # Seems to be the wiki template that will get called
     ADD_INCLUDE = False
     INDENT = 36
 
 
 class MasteryCommandHandler(ExporterHandler):
-    def __init__(self, sub_parser):
+    def __init__(self, sub_parser, *args, **kwargs):
+        super().__init__(self, sub_parser, *args, **kwargs)
         self.parser = sub_parser.add_parser(
             'mastery',
-            help='Mastery exporter',
+            help='Passive Skill Tree Mastery exporter',
         )
         self.parser.set_defaults(func=lambda args: self.parser.print_help())
+        core_sub = self.parser.add_subparsers()
+
+        # Export for each mastery option:
+        mastery_eff_parser = core_sub.add_parser(
+            'effects',
+            help='Mastery exporter for mastery effects (i.e. the bonus you can actually pick)',
+        )
+        mastery_eff_parser.set_defaults(func=lambda args: parser.print_help())
+        mastery_eff_sub = mastery_eff_parser.add_subparsers()
 
         self.add_default_subparser_filters(
-            sub_parser=self.parser.add_subparsers(),
-            cls=MasterySkillParser,
+            sub_parser=mastery_eff_sub,
+            cls=MasteryEffectParser,
         )
 
-        # filtering
-        '''a_filter = sub.add_parser(
-            'filter',
-            help='Extract passives using filters.'
+        # Export for each mastery group:
+        mastery_grp_parser = core_sub.add_parser(
+            'groups',
+            help='Mastery exporter for mastery groups',
         )
-        self.add_default_parsers(
-            parser=a_filter,
-            cls=PassiveSkillParser,
-            func=PassiveSkillParser.by_filter,
-        )
+        mastery_grp_parser.set_defaults(func=lambda args: parser.print_help())
+        mastery_grp_sub = mastery_grp_parser.add_subparsers()
 
-        a_filter.add_argument(
-            '-ft-id', '--filter-id', '--filter-metadata-id',
-            help='Regular expression on the id',
-            type=str,
-            dest='re_id',
-        )'''
+        self.add_default_subparser_filters(
+            sub_parser=mastery_grp_sub,
+            cls=MasteryGroupParser,
+        )
+        # we don't support filtering right now.
 
     def add_default_parsers(self, *args, **kwargs):
         super().add_default_parsers(*args, **kwargs)
@@ -113,10 +128,146 @@ class MasteryCommandHandler(ExporterHandler):
             type=str,
             dest='re_id',
         )
+    
+    def add_default_subparser_filters(self, sub_parser, cls, *args, **kwargs):
+        # By Id
+        super().add_id_subparser_filters(sub_parser, cls, *args, **kwargs)
+
+        # By row id
+        super().add_rowid_subparser_filters(sub_parser, cls, *args, **kwargs)
+
+        # Not by name because name is not available for groups or effects
 
 
-class MasterySkillParser(parser.BaseParser):
+class MasteryEffectParser(parser.BaseParser):
     _MASTERY_FILE_NAME = 'PassiveSkillMasteryEffects.dat'
+    _files = [
+        _MASTERY_FILE_NAME,
+    ]
+
+    _passive_column_index_filter = partialmethod(
+        parser.BaseParser._column_index_filter,
+        dat_file_name=_MASTERY_FILE_NAME,
+        error_msg='Several mastery effects have not been found:\n%s',
+    )
+
+    _MAX_STAT_ID = 3 # How many stats each mastery effect can have.
+
+    _COPY_KEYS = OrderedDict((
+        ('Id', {
+            'template': 'id',
+        }),
+    ))
+
+    def _apply_filter(self, parsed_args, mastery_effs):
+        if parsed_args.re_id:
+            parsed_args.re_id = re.compile(parsed_args.re_id, flags=re.UNICODE)
+        else:
+            return mastery_effs
+
+        new = []
+
+        for mastery_eff in mastery_effs:
+            if parsed_args.re_id and not \
+                    parsed_args.re_id.match(mastery_eff['Id']):
+                continue
+
+            new.append(mastery_eff)
+
+        return new
+
+    def by_rowid(self, parsed_args):
+        return self.export(
+            parsed_args,
+            self.rr[self._MASTERY_FILE_NAME][parsed_args.start:parsed_args.end],
+        )
+
+    def by_id(self, parsed_args):
+        return self.export(parsed_args, self._passive_column_index_filter(
+            column_id='Id', arg_list=parsed_args.id
+        ))
+
+    def export(self, parsed_args, masteries):
+        r = ExporterResult()
+
+        masteries = self._apply_filter(parsed_args, masteries)
+
+        if not masteries:
+            console(
+                'No masteries found for the specified parameters. Quitting.',
+                msg=Msg.warning,
+            )
+            return r
+
+        console('Accessing additional data...')
+
+        # Read from the .dat file
+        self.rr[self._MASTERY_FILE_NAME]
+
+        console(f'Found {len(masteries)}, parsing...')
+
+        for mastery in masteries:
+            data = dict()
+
+            for row_key, copy_data in self._COPY_KEYS.items():
+                value = mastery[row_key]
+
+                condition = copy_data.get('condition')
+                if condition is not None and not condition(mastery):
+                    continue
+
+                # Skip default values to reduce size of template
+                if value == copy_data.get('default'):
+                    continue
+
+                fmt = copy_data.get('format')
+                if fmt:
+                    value = fmt(value)
+                data[copy_data['template']] = value
+
+            stat_ids = []
+            values = []
+
+            one_based_stat_index = 0
+            for stat_index in range(0, self._MAX_STAT_ID):
+                try:
+                    stat = mastery['StatsKeys'][stat_index]
+                except IndexError:
+                    break
+                one_based_stat_index = stat_index + 1
+                stat_ids.append(stat['Id'])
+                data[f'stat{one_based_stat_index}_id'] = stat['Id']
+                values.append(mastery[f'Stat{one_based_stat_index}Value'])
+                data['stat{one_based_stat_index}_value'] = mastery[f'Stat{one_based_stat_index}Value']
+
+            data['stat_text'] = '<br>'.join(self._get_stats(
+                stat_ids, values,
+                translation_file='passive_skill_stat_descriptions.txt'
+            ))
+
+            cond = EffectWikiCondition(
+                data=data,
+                cmdargs=parsed_args,
+            )
+
+            r.add_result(
+                text=cond,
+                out_file='mastery_%s.txt' % data['id'],
+                wiki_page=[
+                    {
+                        'page': 'Mastery Effect:' + self._format_wiki_title(data['id']),
+                        'condition': cond,
+                    },
+                ],
+                wiki_message='Mastery updater',
+            )
+
+        return r
+
+
+
+class MasteryGroupParser(parser.BaseParser):
+    _MASTERY_FILE_NAME = 'PassiveSkillMasteryGroups.dat'
     _files = [
         _MASTERY_FILE_NAME,
     ]
@@ -127,11 +278,13 @@ class MasterySkillParser(parser.BaseParser):
         error_msg='Several masteries have not been found:\n%s',
     )
 
-    _MAX_STAT_ID = 3 # How many stats each one can have.
-
     _COPY_KEYS = OrderedDict((
         ('Id', {
             'template': 'id',
+        }),
+        ('MasteryEffects', {
+            'template': 'mastery_effects',
+            'format': lambda value: ','.join([x['Id'] for x in value]),
         }),
     ))
 
@@ -163,39 +316,33 @@ class MasterySkillParser(parser.BaseParser):
             column_id='Id', arg_list=parsed_args.id
         ))
 
-    def by_name(self, parsed_args):
-        return self.export(parsed_args, self._passive_column_index_filter(
-            column_id='Name', arg_list=parsed_args.name
-        ))
-
-    def export(self, parsed_args, masteries):
+    def export(self, parsed_args, mastery_grps):
         r = ExporterResult()
 
-        masteries = self._apply_filter(parsed_args, masteries)
+        mastery_grps = self._apply_filter(parsed_args, mastery_grps)
 
-        if not masteries:
+        if not mastery_grps:
             console(
-                'No passives found for the specified parameters. Quitting.',
+                'No mastery groups found for the specified parameters. Quitting.',
                 msg=Msg.warning,
             )
             return r
 
         console('Accessing additional data...')
 
+        # Read the .dat file
         self.rr[self._MASTERY_FILE_NAME]
 
-        #self._image_init(parsed_args)
+        console(f'Found {len(mastery_grps)}, parsing...')
 
-        console(f'Found {len(masteries)}, parsing...')
-
-        for mastery in masteries:
+        for mastery_grp in mastery_grps:
             data = dict()
 
             for row_key, copy_data in self._COPY_KEYS.items():
-                value = mastery[row_key]
+                value = mastery_grp[row_key]
 
                 condition = copy_data.get('condition')
-                if condition is not None and not condition(mastery):
+                if condition is not None and not condition(mastery_grp):
                     continue
 
                 # Skip default values to reduce size of template
@@ -207,65 +354,21 @@ class MasterySkillParser(parser.BaseParser):
                     value = fmt(value)
                 data[copy_data['template']] = value
 
-            stat_ids = []
-            values = []
-
-            j = 0
-            for i in range(0, self._MAX_STAT_ID):
-                try:
-                    stat = mastery['StatsKeys'][i]
-                except IndexError:
-                    break
-                j = i + 1
-                stat_ids.append(stat['Id'])
-                data['stat%s_id' % j] = stat['Id']
-                values.append(mastery['Stat%sValue' % j])
-                data['stat%s_value' % j] = mastery['Stat%sValue' % j]
-
-            data['stat_text'] = '<br>'.join(self._get_stats(
-                stat_ids, values,
-                translation_file='passive_skill_stat_descriptions.txt' # this might be wrong
-            ))
-
-            # # For now this is being added to the stat text
-            # for ps_buff in mastery['PassiveSkillBuffsKeys']:
-            #     stat_ids = [stat['Id'] for stat in
-            #                 ps_buff['BuffDefinitionsKey']['StatsKeys']]
-            #     values = ps_buff['Buff_StatValues']
-            #     #if passive['Id'] == 'AscendancyChampion7':
-            #     #    index = stat_ids.index('damage_taken_+%_from_hits')
-            #     #    del stat_ids[index]
-            #     #    del values[index]
-            #     for i, (sid, val) in enumerate(zip(stat_ids, values)):
-            #         j += 1
-            #         data['stat%s_id' % j] = sid
-            #         data['stat%s_value' % j] = val
-
-            #     text = '<br>'.join(self._get_stats(
-            #         stat_ids, values,
-            #         translation_file='passive_skill_aura_stat_descriptions.txt'
-            #     ))
-
-            #     if data['stat_text']:
-            #         data['stat_text'] += '<br>' + text
-            #     else:
-            #         data['stat_text'] = text
-
-            cond = WikiCondition(
+            cond = GroupWikiCondition(
                 data=data,
                 cmdargs=parsed_args,
             )
 
             r.add_result(
                 text=cond,
-                out_file='mastery_%s.txt' % data['id'],
+                out_file='mastery_group_%s.txt' % data['id'],
                 wiki_page=[
                     {
-                        'page': 'Mastery:' + self._format_wiki_title(data['id']),
+                        'page': self._format_wiki_title(data['id']) + " Mastery",
                         'condition': cond,
                     },
                 ],
-                wiki_message='Mastery updater',
+                wiki_message='Mastery Group updater',
             )
 
         return r

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -18727,8 +18727,9 @@ specification = Specification({
                 type='bool',
             ),
             Field(
-                name='Key0',
+                name='SoundEffect',
                 type='ulong',
+                key='SoundEffects.dat'
             ),
         ),
     ),

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -18662,7 +18662,7 @@ specification = Specification({
     'PassiveSkillMasteryEffects.dat': File(
         fields=(
             Field(
-                name='ID',
+                name='Id',
                 type='ref|string',
             ),
             Field(
@@ -18670,7 +18670,7 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Stats',
+                name='StatsKeys',
                 type='ref|list|ulong',
                 key='Stats.dat',
             ),
@@ -18687,11 +18687,22 @@ specification = Specification({
                 type='int',
             ),
         ),
+        virtual_fields=(
+            VirtualField(
+                name='StatValues',
+                fields=('Stat1Value', 'Stat2Value', 'Stat3Value'),
+            ),
+            VirtualField(
+                name='Stats',
+                fields=('StatsKeys', 'StatValues'),
+                zip=True,
+            ),
+        ),
     ),
     'PassiveSkillMasteryGroups.dat': File(
         fields=(
             Field(
-                name='ID',
+                name='Id',
                 type='ref|string',
             ),
             Field(


### PR DESCRIPTION
# Abstract

This supports exporting passive skill tree masteries (mastery groups and the effects you choose within these groups).
It is able to generate wiki template output which is needed by the (in-progress) Mastery group and Mastery effect modules on the wiki. It also supports exporting mastery icons.

# Action Taken

- In handler.py, I added new functions for adding each subparser type, and refactored `add_default_subparser_filters` to call these new functions. This allows parsers to add only some of them much more easily (if for instance, their .dat doesn't have a Name field).
- In stable.py, I updated the spec for some mastery .dat files.
- I created masteries.py, which is a new parser based on the passive skills parser.
It supports exporting mastery groups and mastery effects (the selectable bonuses) as well as images for the masteries.

You can test masteries.py with calls to `pypoe_exporter wiki mastery effects rowid` and `pypoe_exporter wiki mastery groups rowid`.
Image exports use the same parameters and processing as he other image exports.
This fixes #30 

# Caveats

List any issues or gotcha's for this PR or relating to your change in any way, so that it provides transparency toward what could be the
pitfalls of your methods, or perhaps what linked issues/bugs you've uncovered whilst making your changes. Anything that affects functionality
in any way that you feel relevant to mention (especially for other people) should go here.

# FAO

@pm5k @Journeytojah @acbeaumo