### PR TITLE
Hideout decorations

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -872,6 +872,7 @@ class ItemsParser(SkillParserShared):
             'Metadata/Items/Hideout/HideoutRitualTotem': ' (hideout decoration)',
             'Metadata/Items/Hideout/HideoutCharredSkeleton' : " (hideout decoration)",
             'Metadata/Items/Hideout/HideoutVaalWhispySmoke' : " (hideout decoration)",
+            'Metadata/Items/Hideout/HideoutLionStatueKneeling': '',
 
             # =================================================================
             # invitations
@@ -2416,6 +2417,8 @@ class ItemsParser(SkillParserShared):
         'Metadata/Items/Hideout/HideoutShengjingBuildingSupplies3',
         'Metadata/Items/Hideout/HideoutShengjingBuildingSupplies4',
         'Metadata/Items/Hideout/HideoutShengjingBuildingSupplies5',
+
+        'Metadata/Items/Hideout/HideoutLionStatueKneeling2',
 
         #
         # Stackable currency

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -873,6 +873,8 @@ class ItemsParser(SkillParserShared):
             'Metadata/Items/Hideout/HideoutCharredSkeleton' : " (hideout decoration)",
             'Metadata/Items/Hideout/HideoutVaalWhispySmoke' : " (hideout decoration)",
             'Metadata/Items/Hideout/HideoutLionStatueKneeling': '',
+            'Metadata/Items/Hideout/HideoutChurchRuins': ' (hideout decoration)',
+            'Metadata/Items/Hideout/HideoutIncaLetter': ' (hideout decoration)',
 
             # =================================================================
             # invitations


### PR DESCRIPTION
# Abstract

Added page name conflict resolution for hideout decorations that didn't get exported.

# Action Taken

There are two hideout decorations in the game data called "Sitting Lion Statue"; only one of them exists in game. Added page name conflict resolution for the one that exists and placed the other in the skip list.

Added page name conflict resolution for two other hideout decorations whose names conflict with other pages on the wiki.

# Caveats

None. This is a really straightforward PR.

# FAO

