### PR TITLE
Correctly export the max evasion value for armour

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2735,7 +2735,7 @@ class ItemsParser(SkillParserShared):
                 'template': 'evasion_min',
                 'condition': lambda v: v > 0,
             }),
-            ('EvasionMin', {
+            ('EvasionMax', {
                 'template': 'evasion_max',
                 'condition': lambda v: v > 0,
             }),


### PR DESCRIPTION
# Abstract

Correctly export the max evasion value.

# Action Taken

Fix typo so we can correctly export the max evasion value for armour base items.

# Caveats

N/A

# FAO
@pm5k @Journeytojah @acbeaumo
