### PR TITLE
Updates to Mastery Exporting

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/masteries.py
+++ b/PyPoE/cli/exporter/wiki/parsers/masteries.py
@@ -358,6 +358,8 @@ class MasteryGroupParser(parser.BaseParser):
                     value = fmt(value)
                 data[copy_data['template']] = value
 
+            data['name'] = map_id_to_name(data['id'])
+
             # Parse and clean up icon path
             icon_field = 'InactiveIcon'
             if mastery_grp[icon_field]:
@@ -374,7 +376,7 @@ class MasteryGroupParser(parser.BaseParser):
                     pass
             else:
                 data['icon'] = ''
-                warnings.warn(f"Icon path file not found for {mastery_grp['Id']}: {mastery_grp['Name']}")
+                warnings.warn(f"Icon path file not found for {mastery_grp['Id']}: {data['name']}")
 
             data['icon'] = data['icon'].replace('.dds', '')
 
@@ -398,10 +400,10 @@ class MasteryGroupParser(parser.BaseParser):
 
             r.add_result(
                 text=cond,
-                out_file='mastery_group_%s.txt' % data['id'],
+                out_file='mastery_group_%s.txt' % data['name'],
                 wiki_page=[
                     {
-                        'page': self._format_wiki_title(data['id']) + " Mastery",
+                        'page': self._format_wiki_title(data['name']),
                         'condition': cond,
                     },
                 ],
@@ -413,3 +415,31 @@ class MasteryGroupParser(parser.BaseParser):
 # =============================================================================
 # Functions
 # =============================================================================
+
+def map_id_to_name(id: str):
+    mastery_type = ''
+    if(id in id_to_name_map.keys()):
+        mastery_type = id_to_name_map[id]
+    else:
+        mastery_type = id
+    
+    return mastery_type + " Mastery"
+    
+# The names used ingame are the names of the passive skills, and you never actually see names for 
+# the mastery objects. I don't want to parse the entire passives dat file to get these names and there's 
+# just a few so I'm hardcoding this mapping for now.
+id_to_name_map = {
+    'ArmourEvasion': 'Armour and Evasion',
+    'ArmourEnergyShield': 'Armour and Energy Shield',
+    'Charges': 'Charge',
+    'Criticals': 'Critical',
+    'DamageOverTime': 'Damage Over Time',
+    'DualWield': 'Dual Wielding',
+    'EnergyShield': 'Energy Shield',
+    'EvasionEnergyShield': 'Evasion and Energy Shield',
+    'MinionDefence': 'Minion Defence',
+    'MinionOffence': 'Minion Offence',
+    'Suppression': 'Spell Suppression',
+    'TwoHand': 'Two Hand',
+    'Resistance': 'Resistance and Ailment Protection',
+}

--- a/PyPoE/cli/exporter/wiki/parsers/masteries.py
+++ b/PyPoE/cli/exporter/wiki/parsers/masteries.py
@@ -404,7 +404,7 @@ class MasteryGroupParser(parser.BaseParser):
 
             r.add_result(
                 text=cond,
-                out_file='mastery_group_%s.txt' % data['name'],
+                out_file=f"mastery_group_{data['name']}.txt",
                 wiki_page=[
                     {
                         'page': self._format_wiki_title(data['name']),
@@ -422,7 +422,7 @@ class MasteryGroupParser(parser.BaseParser):
         # Find the passive skills that let you allocate masteries, and match the mastery groups
         # they're linked to to the name of the passive skills
         for passive in passives:
-            if not passive['MasteryGroup'] is None:
+            if passive['MasteryGroup'] is not None:
                 name_map[passive['MasteryGroup']['Id']] = passive['Name']
         return name_map
 


### PR DESCRIPTION
# Abstract

Adds a Name field to Mastery Groups, which is pulled from passive skills that let you allocate the masteries.

# Action Taken

On the wiki, there was need for a user-facing name for Mastery Groups in addition to the internal ID (which was already readable, but never had spaces and would differ from the in-game wording in some cases.
I've updated the mastery export to determine those names using the skill tree and to save them in the wiki exports.

# Caveats

The mastery export is now dependent on the passive tree data structure.
This is better than being dependent on a hard-coded mapping of mastery groups to names.

# FAO

@pm5k @Journeytojah @acbeaumo
