### PR TITLE
Updating the beast rarity handling to match current data.

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -3590,7 +3590,7 @@ class ItemsParser(SkillParserShared):
             if rarity.id >= 5:
                 break
             # for i, (item, cost) in enumerate(
-            #         source[rarity.name_upper + 'Purchase'],
+            #         source[rarity.name_lower.title() + 'Purchase'],
             #         start=1):
             #     prefix = 'purchase_cost_%s%s' % (rarity.name_lower, i)
             #     infobox[prefix + '_name'] = item['Name']

--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -506,8 +506,8 @@ class BestiaryParser(GenericLuaParser):
             self._copy_from_keys(
                 row, self._COPY_KEYS_BESTIARY_COMPONENTS, components
             )
-            if row['BeastRarity'] != RARITY.ANY and not (row['BeastRarity'] is None):
-                display_string = 'ItemDisplayString' + row['BeastRarity'].name_upper
+            if row['BeastRarity'] != RARITY.ANY and row['BeastRarity'] is not None:
+                display_string = 'ItemDisplayString' + row['BeastRarity'].name_lower.title()
                 components[-1]['rarity'] = self.rr['ClientStrings.dat'].index['Id'][display_string]['Text']
 
         recipe_components = []

--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -506,7 +506,7 @@ class BestiaryParser(GenericLuaParser):
             self._copy_from_keys(
                 row, self._COPY_KEYS_BESTIARY_COMPONENTS, components
             )
-            if row['BeastRarity'] != RARITY.ANY:
+            if row['BeastRarity'] != RARITY.ANY and not (row['BeastRarity'] is None):
                 display_string = 'ItemDisplayString' + row['BeastRarity'].name_upper
                 components[-1]['rarity'] = self.rr['ClientStrings.dat'].index['Id'][display_string]['Text']
 

--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -568,34 +568,37 @@ class RARITY(Enum, metaclass=IntEnumMetaOverride):
         Unique rarity ("brown" colour)
     ANY : RARITY
         Any rarity
-    id : int
-        When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
-        the id attribute denotes the integer that is sometimes used in the game
-        files to represent the colour
-    name_upper : str
-        When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
-        the upper attribute represents the textual representation with an upper
-        case starting letter
-    name_lower : str
-        When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
-        the lower attribute represents the textual representation with an lower
-        case starting letter
-    colour : str
-        When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
-        the colour attribute represents the textual representation of the
-        associated colour
     """
-    NORMAL = (0, 'Normal', 'normal', 'white')
-    MAGIC = (1, 'Magic', 'magic', 'blue')
-    RARE = (2, 'Rare', 'rare', 'yellow')
-    UNIQUE = (3, 'Unique', 'unique', 'brown')
-    ANY = (5, 'Any', 'any', 'any')
 
-    def __new__(cls, id, upper, lower, colour):
+    id: int
+    """
+    When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
+    the id attribute denotes the integer that is sometimes used in the game
+    files to represent the colour
+    """
+    name_lower: str
+    """
+    When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
+    the name_lower attribute represents the textual representation with an lower
+    case starting letter
+    """
+    colour: str
+    """
+    When accessing a :class:`RARITY` instance (e.x. :attr:`RARITY.NORMAL`)
+    the colour attribute represents the textual representation of the
+    associated colour
+    """
+
+    NORMAL = (0, 'normal', 'white')
+    MAGIC = (1, 'magic', 'blue')
+    RARE = (2, 'rare', 'yellow')
+    UNIQUE = (3, 'unique', 'brown')
+    ANY = (5, 'any', 'any')
+
+    def __new__(cls, id: int, lower: str, colour: str):
         obj = object.__new__(cls)
         obj._value_ = id
         obj.id = id
-        obj.name_upper = upper
         obj.name_lower = lower
         obj.colour = colour
         return obj

--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -585,10 +585,10 @@ class RARITY(Enum, metaclass=IntEnumMetaOverride):
         the colour attribute represents the textual representation of the
         associated colour
     """
-    NORMAL = (1, 'Normal', 'normal', 'white')
-    MAGIC = (2, 'Magic', 'magic', 'blue')
-    RARE = (3, 'Rare', 'rare', 'yellow')
-    UNIQUE = (4, 'Unique', 'unique', 'brown')
+    NORMAL = (0, 'Normal', 'normal', 'white')
+    MAGIC = (1, 'Magic', 'magic', 'blue')
+    RARE = (2, 'Rare', 'rare', 'yellow')
+    UNIQUE = (3, 'Unique', 'unique', 'brown')
     ANY = (5, 'Any', 'any', 'any')
 
     def __new__(cls, id, upper, lower, colour):

--- a/PyPoE/poe/sim/item.py
+++ b/PyPoE/poe/sim/item.py
@@ -559,7 +559,7 @@ class ItemParser:
 
             rarity = rarity.group('rarity')
             for rarity_const in RARITY:
-                if rarity_const.name_upper == rarity:
+                if rarity_const.name_lower == rarity.lower():
                     self.rarity = rarity_const
                     self._type = ITEM_TYPES.ITEM
                     break


### PR DESCRIPTION
# Abstract

I updated the bestiary export so it works for 3.16.

# Action Taken

There are now some rows in the BestiaryRecipeComponent.dat where BeastRarity is null.
These were not handled properly by the export. We now treat these the same way as we treated beasts with a rarity of "Any" previously - by ignoring their rarity.
It seems that the Rarity.dat now counts up from 0 instead of 1, so I have shifted the rarity enum to start with 0 instead of 1.
This makes it so the rarity requirements of beasts is correct in the exports.

# Caveats

N/A

# FAO

@pm5k @Journeytojah @acbeaumo
