### PR TITLE
Fix Delve export, Mark Old Watchstones as Drop-Disabled, and Allow Passive Image Exports

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -594,7 +594,7 @@ class ItemsParser(SkillParserShared):
         'Metadata/Items/Currency/CurrencyImprint',
         # Transmute Shard
         'Metadata/Items/Currency/CurrencyUpgradeToMagicShard',
-        'Metadata/Items/Currency/CurrencyIdentificationShard'
+        'Metadata/Items/Currency/CurrencyIdentificationShard',
     }
 
     _DROP_DISABLED_ITEMS_BY_ID = {
@@ -610,6 +610,25 @@ class ItemsParser(SkillParserShared):
         # Demigod items
         'Metadata/Items/Belts/BeltDemigods1',
         'Metadata/Items/Rings/RingDemigods1',
+        'Metadata/Items/AtlasUpgrades/AtlasRegionUpgradeFinal', # Ivory Watchstone Base Item
+        
+        # Old Watchstones
+        # Tirn's End:
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable1_2',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable2_2',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable3_2',
+        # Lex Proxima:
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable1_3',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable2_3',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable3_3',
+        # Lex Ejoris:
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable1_4',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable2_4',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable3_4',
+        # New Vastir:
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable1_5',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable2_5',
+        'Metadata/Items/AtlasUpgrades/AtlasUpgradeCraftable3_5',
     }
 
     _NAME_OVERRIDE_BY_ID = {

--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -749,6 +749,9 @@ class DelveParser(GenericLuaParser):
                 delve_upgrade_stats[-1]['value'] = value
 
         for row in self.rr['DelveCraftingModifiers.dat']:
+            # Ignore all the weird RandomFossileOutcome items.
+            if('RandomFossilOutcome' in row['BaseItemTypesKey']['Id']):
+                continue
             self._copy_from_keys(row, self._COPY_KEYS_DELVE_CRAFTING_MODIFIERS,
                                  fossils)
 

--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -362,7 +362,7 @@ class PassiveSkillParser(parser.BaseParser):
                         psg_id]['Id'] for psg_id in node.connections])
 
             # extract icons if specified
-            if parsed_args.store_images:
+            if parsed_args.store_images and data['icon'] != '':
                 fn = data['icon'] + ' passive skill icon'
                 dds = os.path.join(self._img_path, fn + '.dds')
                 png = os.path.join(self._img_path, fn + '.png')

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -6249,6 +6249,10 @@ specification = Specification({
                 name='Unknown5',
                 type='int',
             ),
+            Field( 
+                name='Unknown6', #This is pobably endless delve mosnter level scaling.
+                type='int',
+            ),
         ),
     ),
     'DelveMonsterSpawners.dat': File(

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -6214,11 +6214,11 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='MoreMonsterLife',
+                name='MoreMonsterDamage',
                 type='int',
             ),
             Field(
-                name='MoreMonsterDamage',
+                name='MoreMonsterLife',
                 type='int',
             ),
             Field(
@@ -6250,7 +6250,7 @@ specification = Specification({
                 type='int',
             ),
             Field( 
-                name='Unknown6', #This is pobably endless delve mosnter level scaling.
+                name='EndlessDelveMonsterLevel', #This is pobably endless delve mosnter level scaling.
                 type='int',
             ),
         ),


### PR DESCRIPTION
# Abstract

I updated the delve export and spec so it works for 3.16.
I also did a couple misc. fixes:
- Watchstones from non-existent regions are now automatically flagged as drop-disabled.
- Passive image exporting won't crash when it finds a passive with no icon path.

# Action Taken

The spec for DelveLevelScaling.dat was missing a field.
I added that field.
Exports for fossils and fossil weights were including 420 (heh) random fossil outcomes from the new tangled fossil.
I've excluded these random outcomes from the exports since they don't seem useful.


Misc. fixes:
- Watchstones from non-existent regions were added to the constant for drop-disabled items.
- We won't try to export passive images if we don't have any image path.

# Caveats

We may run into something down the line where we want to export the 420 tangled fossil outcomes.

# FAO

@pm5k @Journeytojah @acbeaumo