### PR TITLE
Page name conflict resolution for new series of quiver base types in …

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -826,8 +826,40 @@ class ItemsParser(SkillParserShared):
             # =================================================================
             # Quivers
             # =================================================================
-
+            
+            # Serrated Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew1': '',
+            'Metadata/Items/Quivers/Quiver6': ' (legacy)',
             'Metadata/Items/Quivers/QuiverDescent': ' (Descent)',
+
+            # Two-Point Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew7': '',
+            'Metadata/Items/Quivers/Quiver7': ' (legacy)',
+
+            # Sharktooth Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew3': '',
+            'Metadata/Items/Quivers/Quiver8': ' (legacy)',
+
+            # Blunt Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew6': '',
+            'Metadata/Items/Quivers/Quiver9': ' (legacy)',
+
+            # Fire Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew2': '',
+            'Metadata/Items/Quivers/Quiver10': ' (legacy)',
+
+            # Broadhead Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew10': '',
+            'Metadata/Items/Quivers/Quiver11': ' (legacy)',
+
+            # Penetrating Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew5': '',
+            'Metadata/Items/Quivers/Quiver12': ' (legacy)',
+
+            # Spike-Point Arrow Quiver
+            'Metadata/Items/Quivers/QuiverNew8': '',
+            'Metadata/Items/Quivers/Quiver13': ' (legacy)',
+
             # =================================================================
             # Rings
             # =================================================================


### PR DESCRIPTION
# Abstract

Version 3.17.0 of Path of Exile added a brand new series of quiver base types. These are all new items in the game data, even those that share the same names as the legacy quivers. It is therefore necessary to distinguish the new quivers from their legacy counterparts.

# Action Taken

Added page name conflict resolution for the new series of quiver base types in version 3.17.0. The page titles for legacy quivers will be appended with the parenthetical text, "(legacy)".

# Caveats

The existing quiver pages on the wiki where there would be a conflict should first be moved in order to maintain revision history cohesion. For example, "Serrated Arrow Quiver" should be moved to "Serrated Arrow Quiver (legacy)".