### PR TITLE
Copy eldritch modifier flags that must be added to the wiki template …

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -143,6 +143,8 @@ class WikiCondition(parser.WikiCondition):
         'is_corrupted',
         'is_fractured',
         'is_synthesised',
+        'is_searing_exarch_item',
+        'is_eater_of_worlds_item',
         'is_veiled',
         'is_replica',
         'is_relic',


### PR DESCRIPTION
# Abstract

Copy eldritch modifier flags that must be added to the wiki template manually.

# Action Taken

The item flags `is_searing_exarch_item` and `is_eater_of_worlds_item` will be added to the wiki's item template. These must be specified as keys to copy, otherwise the PyPoE exporter will remove them.

# Caveats

This PR should be merged before the exports are done for version 3.18.0.

# FAO

@pm5k @AlphSpirit
