### PR TITLE
Allow Exporting from 3.18 Game Data

### DIFF
--- a/PyPoE/cli/exporter/wiki/handler.py
+++ b/PyPoE/cli/exporter/wiki/handler.py
@@ -33,7 +33,6 @@ See PyPoE/LICENSE
 import os
 import time
 import re
-import sys
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from requests.exceptions import HTTPError
@@ -217,7 +216,6 @@ class WikiHandler:
 
     def handle(self, *a, mwclient, result, cmdargs, parser):
         # First row is handled separately to prompt the user for his password
-        sys.stdout.reconfigure(encoding='utf-8')
 
         url = WIKIS.get(config.get_option('language'))
         if url is None:

--- a/PyPoE/cli/exporter/wiki/handler.py
+++ b/PyPoE/cli/exporter/wiki/handler.py
@@ -33,6 +33,7 @@ See PyPoE/LICENSE
 import os
 import time
 import re
+import sys
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from requests.exceptions import HTTPError
@@ -216,6 +217,8 @@ class WikiHandler:
 
     def handle(self, *a, mwclient, result, cmdargs, parser):
         # First row is handled separately to prompt the user for his password
+        sys.stdout.reconfigure(encoding='utf-8')
+
         url = WIKIS.get(config.get_option('language'))
         if url is None:
             console(

--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -723,7 +723,8 @@ class MOD_DOMAIN(IntEnumOverride):
     EXPEDITION_RELIC = 27
     UNVEILED = 28
     PRIMORDIAL_ALTAR = 29
-    UNCRAFTABLE_OR_SOMETHING = 30 # Used in BaseItemTypes.dat, not Mods.dat.
+    SENTINEL = 30
+    MODS_DISALLOWED = 31 # Used in BaseItemTypes.dat, not Mods.dat.
 
     # legacy names
     MASTER = CRAFTED

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -18007,6 +18007,10 @@ specification = Specification({
                 name='Key2',
                 type='ulong',
             ),
+            Field(
+                name='HasAreaMissions',
+                type='bool',
+            ),
         ),
     ),
     'NPCPortraits.dat': File(
@@ -23716,6 +23720,10 @@ specification = Specification({
             Field(
                 name='Unknown52',
                 type='ulong',
+            ),
+            Field(
+                name='Unknown53',
+                type='int',
             ),
         ),
     ),

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -1445,7 +1445,7 @@ specification = Specification({
             ),
             Field(
                 name='CharactersKey',
-                type='ulong',
+                type='ref|list|ulong',
                 key='Characters.dat',
             ),
             Field(
@@ -1484,6 +1484,11 @@ specification = Specification({
             Field(
                 name='Unknown1',
                 type='int',
+            ),
+            Field(
+                name='BackgroundImage',
+                type='ref|string',
+                file_path=True,
             ),
         ),
     ),
@@ -2182,9 +2187,13 @@ specification = Specification({
                 type='int',
                 enum='MOD_DOMAIN',
             ),
+            # Field(
+            #     name='IsDropDisabled',
+            #     type='bool',
+            # ),
             Field(
-                name='IsDropDisabled',
-                type='bool',
+                name='Unknown0',
+                type='int',
             ),
             Field(
                 name='ItemVisualIdentityKey',
@@ -2212,7 +2221,7 @@ specification = Specification({
                 key='AchievementItems.dat',
             ),
             Field(
-                name='IsCorrupted',
+                name='IsUnmodifiable',
                 type='bool',
             ),
             Field(
@@ -3893,16 +3902,12 @@ specification = Specification({
                 type='bool',
             ),
             Field(
-                name='Key1',
-                type='ulong',
+                name='Keys0',
+                type='ref|list|ulong',
             ),
             Field(
                 name='Flag17',
                 type='bool',
-            ),
-            Field(
-                name='Keys0',
-                type='ref|list|ulong',
             ),
             Field(
                 name='Keys1',
@@ -3917,16 +3922,36 @@ specification = Specification({
                 type='ref|list|ulong',
             ),
             Field(
-                name='Unknown5',
-                type='int',
+                name='Keys4',
+                type='ref|list|ulong',
             ),
             Field(
                 name='Flag18',
                 type='bool',
             ),
             Field(
-                name='Key2',
+                name='Flag19',
+                type='bool',
+            ),
+            Field(
+                name='Flag20',
+                type='bool',
+            ),
+            Field(
+                name='Flag21',
+                type='bool',
+            ),
+            Field(
+                name='Flag22',
+                type='bool',
+            ),
+            Field(
+                name='Key1',
                 type='ulong',
+            ),
+            Field(
+                name='Data1',
+                type='ref|list|int',
             ),
         ),
     ),
@@ -3987,6 +4012,11 @@ specification = Specification({
             Field(
                 name='Flag1',
                 type='bool',
+            ),
+            Field(
+                name='SentinelStat', # Looks Sentinel-related.
+                type='ulong',
+                key='Stats.dat',
             ),
         ),
     ),
@@ -9185,6 +9215,22 @@ specification = Specification({
                 type='ref|generic',
                 key='GrantedEffects.dat',
             ),
+            Field(
+                name='Unknown3',
+                type='int',
+            ),
+            Field(
+                name='Unknown4',
+                type='int',
+            ),
+            Field(
+                name='Unknown5',
+                type='int',
+            ),
+            Field(
+                name='Flag4',
+                type='bool',
+            ),
         ),
     ),
     'GrantedEffectsPerLevel.dat': File(
@@ -12384,7 +12430,19 @@ specification = Specification({
             Field( # added in 3.17
                 name='Flag1',
                 type='bool',
-            )
+            ),
+            Field( # added in 3.18
+                name='Flag2',
+                type='bool',
+            ),
+            Field(
+                name='SizeDimensions', # Hybrid Flasks seems wrong for this but the rest seems to match.
+                type='ref|list|int',
+            ),
+            Field(
+                name='Flags',
+                type='ref|list|int',
+            ),
         ),
     ),
     'ItemCostPerLevel.dat': File(
@@ -15960,6 +16018,10 @@ specification = Specification({
                 name='Hash32',
                 type='int',
             ),
+            Field(
+                name='Keys0',
+                type='ref|list|ulong',
+            ),
         ),
         virtual_fields=(
             VirtualField(
@@ -18913,6 +18975,10 @@ specification = Specification({
                 name='AtlasInfluenceSet',
                 type='ulong',
                 #key='AtlasInfluenceSets.dat', FIXME: Define spec
+            ),
+            Field(
+                name='Key0', #Used by the atlas keystones. Values from 380-392
+                type='ulong',
             ),
         ),
         virtual_fields=(

--- a/PyPoE/poe/sim/mods.py
+++ b/PyPoE/poe/sim/mods.py
@@ -80,6 +80,8 @@ _translation_map = {
     # To properly support zana's innate IIQ
     MOD_DOMAIN.CRAFTED: 'map_stat_descriptions.txt',
     MOD_DOMAIN.HEIST_NPC: 'heist_equipment_stat_descriptions.txt',
+    MOD_DOMAIN.PRIMORDIAL_ALTAR: 'primordial_altar_stat_descriptions.txt',
+    MOD_DOMAIN.SENTINEL: 'sentinel_stat_descriptions.txt',
 }
 
 # =============================================================================


### PR DESCRIPTION
# Abstract

Update .dat specs 
A quick one/two sentence "shot" of what was done in this PR so people can understand at a glance.

# Action Taken

Allowed Mod Exporting for 3.18:
- Added mod domain 30 (and bump down 31)
- Updated dat specs as needed to export mods.
- Specified translation files for a couple of modifier domains.

Allowed Item Exporting for 3.18:
- Updated dat specs as needed

# Caveats

This isn't fully reviewed for the changes that will result on the wiki if all item exports are performed.
It doesn't handle sentinels well yet.
I'm going to merge these changes in since they're very tame and so people can use patches for more 3.18 stuff (incl. other changes we're making as a team).

# FAO
n/a since I'm going to just merge this in.