### PR TITLE
#81 point 8.

### DIFF
--- a/PyPoE/cli/exporter/wiki/admin/unique.py
+++ b/PyPoE/cli/exporter/wiki/admin/unique.py
@@ -248,7 +248,7 @@ class UniqueCopy(BaseParser):
 
         # Add inventory icon so it shows up correctly
         if not mwtemplate.has('inventory_icon'):
-            mwtemplate.add('{0: <40}'.format('inventory_icon'), name)
+            mwtemplate.add('inventory_icon'.ljust(40, ' '), name)
 
         # Find translated item name
         console('Finding item name...')

--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1877,17 +1877,17 @@ def format_result_rows(parsed_args, ordered_dict, template_name,
     out = []
 
     if parsed_args.format == 'template':
-        out = ['{{%s\n' % template_name]
+        out = [f'{{{{{template_name}\n']
         for k, v in ordered_dict.items():
             if v is not None:
-                out.append(('|{0: <%s}= {1}\n' % indent).format(k, v))
+                out.append(f'|{k: <{indent}}= {v}\n')
         out.append('}}')
     elif parsed_args.format == 'module':
         ordered_dict['debug_id'] = 1
         out = ['{']
         for k, v in ordered_dict.items():
             if v is not None:
-                out.append('{0} = "{1}", '.format(k, v))
+                out.append(f'{k} = "{v}", ')
         out[-1] = out[-1].strip(', ')
         out.append('}')
     return ''.join(out)

--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1873,6 +1873,9 @@ def format_result_rows(parsed_args, ordered_dict, template_name,
     out : str
         formatted string
     """
+    assert indent >= 0
+    out = []
+
     if parsed_args.format == 'template':
         out = ['{{%s\n' % template_name]
         for k, v in ordered_dict.items():

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2832,7 +2832,7 @@ class ItemsParser(SkillParserShared):
             ('RecoveryTime', {
                 'template': 'flask_duration',
                 'condition': lambda v: v > 0,
-                'format': lambda v: '{0:n}'.format(v / 10),
+                'format': lambda v: f'{v / 10:n}',
             }),
             ('BuffDefinitionsKey', {
                 'template': 'buff_id',
@@ -2862,11 +2862,11 @@ class ItemsParser(SkillParserShared):
         data_mapping=(
             ('Critical', {
                 'template': 'critical_strike_chance',
-                'format': lambda v: '{0:n}'.format(v / 100),
+                'format': lambda v: f'{v / 100:n}',
             }),
             ('Speed', {
                 'template': 'attack_speed',
-                'format': lambda v: '{0:n}'.format(round(1000 / v, 2)),
+                'format': lambda v: f'{round(1000 / v, 2):n}',
             }),
             ('DamageMin', {
                 'template': 'physical_damage_min',

--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -163,7 +163,7 @@ class SkillParserShared(parser.BaseParser):
         # ('ManaCost', {
         #     'template': 'mana_cost',
         #     'default': 0,
-        #     'format': lambda v: '{0:n}'.format(v),
+        #     'format': lambda v: f'{v:n}',
         # }),
         ('CostAmounts', {
             'template': 'cost_amounts',
@@ -181,75 +181,75 @@ class SkillParserShared(parser.BaseParser):
         }),
         ('ManaMultiplier', {
             'template': 'mana_multiplier',
-            'format': lambda v: '{0:n}'.format(v),
+            'format': lambda v: f'{v:n}',
             'skip_active': True,
         }),
         ('StoredUses', {
             'template': 'stored_uses',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v),
+            'format': lambda v: f'{v:n}',
         }),
         ('Cooldown', {
             'template': 'cooldown',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v/1000),
+            'format': lambda v: f'{v/1000:n}',
         }),
         ('VaalSouls', {
             'template': 'vaal_souls_requirement',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v),
+            'format': lambda v: f'{v:n}',
         }),
         ('VaalStoredUses', {
             'template': 'vaal_stored_uses',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v),
+            'format': lambda v: f'{v:n}',
         }),
         ('VaalSoulGainPreventionTime', {
             'template': 'vaal_soul_gain_prevention_time',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v/1000),
+            'format': lambda v: f'{v/1000:n}',
         }),
         ('CriticalStrikeChance', {
             'template': 'critical_strike_chance',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v/100),
+            'format': lambda v: f'{v/100:n}',
         }),
         ('DamageEffectiveness', {
             'template': 'damage_effectiveness',
-            'format': lambda v: '{0:n}'.format(v+100),
+            'format': lambda v: f'{v+100:n}',
         }),
         ('DamageMultiplier', {
             'template': 'damage_multiplier',
-            'format': lambda v: '{0:n}'.format(v/100+100),
+            'format': lambda v: f'{v/100+100:n}',
         }),
         ('AttackSpeedMultiplier', {
             'template': 'attack_speed_multiplier',
-            'format': lambda v: '{0:n}'.format(v+100),
+            'format': lambda v: f'{v+100:n}',
         }),
         ('BaseDuration', {
             'template': 'duration',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v / 1000),
+            'format': lambda v: f'{v / 1000:n}',
         }),
         ('ManaReservationFlat', {
             'template': 'mana_reservation_flat',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v),
+            'format': lambda v: f'{v:n}',
         }),
         ('ManaReservationPercent', {
             'template': 'mana_reservation_percent',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v/100),
+            'format': lambda v: f'{v/100:n}',
         }),
         ('LifeReservationFlat', {
             'template': 'life_reservation_flat',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v),
+            'format': lambda v: f'{v:n}',
         }),
         ('LifeReservationPercent', {
             'template': 'life_reservation_percent',
             'default': 0,
-            'format': lambda v: '{0:n}'.format(v/100),
+            'format': lambda v: f'{v/100:n}',
         }),
     )
 

--- a/PyPoE/poe/patchserver.py
+++ b/PyPoE/poe/patchserver.py
@@ -148,13 +148,13 @@ def node_check_hash(directory_node, folder_path=None, ggpk=None,
         node_hashes = node_check_hash(node, ggpk=ggpk)
 
         if node_hashes[-1][2] is True:
-          print('hashes match for {}'.format(node.get_path()))
+          print(f'hashes match for {node.get_path()}')
         else:
           for child_node, child_hash, child_bool in node_hashes:
             if bool is False:
               print(child_node.record.name)
-              print('{} file hash'.format(child_hash.hexdigest()))
-              print('{:064x} expected hash'.format(child_node.record.hash))
+              print(f'{child_hash.hexdigest()} file hash')
+              print(f'{child_node.record.hash:064x} expected hash')
 
         # up to date?
         import PyPoE.poe.patchserver
@@ -180,7 +180,7 @@ def node_check_hash(directory_node, folder_path=None, ggpk=None,
             node_patchserver_results.append(hash_test)
 
         if list(zip(node_hashes, node_patchserver_results))[-1][1] is True:
-          print('hashes match patchserver for {}'.format(test_node))
+          print(f'hashes match patchserver for {test_node}')
 
     Example files::
 
@@ -193,9 +193,7 @@ def node_check_hash(directory_node, folder_path=None, ggpk=None,
         node_hash_list = PyPoE.poe.patchserver.node_check_hash(
           patch_file_list.directory, folder_path=poe_dir, recurse=False)
         for node, checksum, matched in node_hash_list:
-          print('{} hashed okay?: {}'.format(
-            node.record.name,
-            matched))
+          print(f'{node.record.name} hashed okay?: {matched}')
 
     Parameters
     ---------
@@ -482,11 +480,10 @@ def node_update_files(patch_file_list, directory_node_path,
         pretty_hash = format(hash, '064x')
         dst_file = os.path.join(folder_path, files_subdir, pretty_hash)
         node_file_name = nodes[0].get_path()
-        print("{} file downloads remaining".format(
-            files_count - download_index))
+        print(f"{files_count - download_index} file downloads remaining")
         patch_file_list.patch.download(node_file_name,
                                        dst_file=dst_file)
-        print("downloaded: {}".format(node_file_name))
+        print(f"downloaded: {node_file_name}")
         download_index += 1
 
         for node in nodes:
@@ -1006,15 +1003,13 @@ class PatchFileList:
             folder_name = ''
             if query_header != PatchFileList._PROTO_HEADER2:
                 raise KeyError('Unknown patch server header:'
-                               + ' {} from query: {}'
-                               .format(query_header, folder_query))
+                               f' {query_header} from query: {folder_query}')
 
             folder_name = self.extract_varchar()
 
             item_count = struct.unpack('>I', self.read(4))[0]
 
-            print('{} items in directory {}'
-                  .format(item_count, folder_name))
+            print(f'{item_count} items in directory {folder_name}')
 
             parent = self.directory[folder]
 
@@ -1028,9 +1023,8 @@ class PatchFileList:
                     tag = 'PDIR'
                 else:
                     raise KeyError('Unknown patch server'
-                                   + ' item type:'
-                                   + ' {} from query: {}'
-                                   .format(header, folder_query))
+                                   ' item type:'
+                                   f' {header} from query: {folder_query}')
 
                 name = self.extract_varchar()
 
@@ -1212,8 +1206,7 @@ class DirectoryNodeExtended(DirectoryNode):
                     hash=node_hash)
 
             else:
-                raise KeyError('Unknown type: {}'.format(
-                    node_type))
+                raise KeyError(f'Unknown type: {node_type}')
 
         if parent is None:
             self.record = temp_record
@@ -1246,8 +1239,7 @@ class DirectoryNodeExtended(DirectoryNode):
                 name = node.record.name
               except:
                 name = 'ROOT'
-              print('{blank:>{width}}{name}'.format(
-                name=name, width=depth, blank=''))
+              print(f'{name:>{depth + len(name)}}')
 
         Parameters
         ---------

--- a/tests/PyPoE/cli/exporter/wiki/test_parser.py
+++ b/tests/PyPoE/cli/exporter/wiki/test_parser.py
@@ -354,7 +354,6 @@ def test_find_template(string, template, texts, args, kwargs):
     assert result['kwargs'] == kwargs
 
 
-# TODO
 @pytest.mark.parametrize('input_data,expected_result', frrdata)
 def test_format_result_rows(input_data, expected_result):
     result = parser.format_result_rows(


### PR DESCRIPTION
# Abstract

Fix for point 8. of Issue #81 aka changing from use of 'format' to f-strings.

# Action Taken

Provided unit tests for 'format_result_rows' function and removed all the 'format(...)' uses on strings. Also added an assertion for 'index' and initialized the 'out' variable at the very beginning to ensure that all execution paths work properly.

# Caveats

There are three things that bother me.
1. I don't know how to test all the changes. When I invoke tests, they require a lot of dependencies. I'm not used to that to be honest.
2. The change in [PyPoE/cli/exporter/wiki/admin/unique.py](https://github.com/Project-Path-of-Exile-Wiki/PyPoE/compare/dev...ashrasmun:issue81p8?expand=1#diff-d5def251bc05f3f8f6cdca4e72777e8909023a3c3f46f784810298f79ecb811d) is confusing for me. I removed the 'format' use and kept it consistent, but I don't understand why do we add a key named 'inventory_icon                                  ' if we do not find the 'inventory_icon' key. Should it be that way or is it a bug?
3. I introduced 'FakeArgsObject' in tests, but I think the proper thing would be to change 'format_result_rows' so that it accepts a string instead of an object. I believe there's no reason for this function to accept whole object if only one field is used.

# FAO

After consultation with @pm5k, I'd like to ask @zao and @angelic-knight to take a quick look at the second issue from the Caveats section above.