### PR TITLE
Fix constant dynamic stats being seen as static

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -462,13 +462,15 @@ class SkillParserShared(parser.BaseParser):
                     static['columns'].remove(key)
                     dynamic['columns'].add(key)
             for key in list(static['stats']):
-                if key not in last['stats']:
-                    continue
-                if key not in data['stats']:
+                in_last = key in last['stats']
+                in_data = key in data['stats']
+                if not in_last and not in_data:
                     continue
 
-                if last['stats'][key]['values'] != data['stats'][key][
-                        'values']:
+                # Consider a stat dynamic if it changes presence
+                # or value between levels.
+                if in_last != in_data or (last['stats'][key]['values'] !=
+                        data['stats'][key]['values']):
                     del static['stats'][key]
                     dynamic['stats'][key] = None
             last = data


### PR DESCRIPTION
# Abstract

Dynamic stats are ones that change value across skill levels. Previously stats were considered dynamic if they had different values across skill levels but didn't consider changes in presence between skill levels.

# Action Taken

This fixes that problem by considering something dynamic if it either changes presence or changes value.

# Caveats

As the wiki currently has incorrect data due to this bug for several support skill gems like Awakened Burning Damage Support, the data for support skill gems should be regenerated once this is merged.