### PR TITLE
Support for Sentinel Map Series & Duplicate Spec Field Name Validation

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -398,6 +398,7 @@ class ItemsParser(SkillParserShared):
         'Expedition': '3.15.0',
         'Hellscape': '3.16.0', # AKA Scourge
         'Archnemesis': '3.17.0',
+        'Sentinel': '3.18.0',
     }
 
     _IGNORE_DROP_LEVEL_CLASSES = (

--- a/PyPoE/cli/exporter/wiki/parsers/mods.py
+++ b/PyPoE/cli/exporter/wiki/parsers/mods.py
@@ -246,7 +246,7 @@ class ModParser(BaseParser):
             # todo ID for GEPL
             if mod['GrantedEffectsPerLevelKeys']:
                 data['granted_skill'] = ', '.join(
-                    [k['GrantedEffectsKey']['Id'] for k in
+                    [k['GrantedEffect']['Id'] for k in
                      mod['GrantedEffectsPerLevelKeys']])
             data['mod_type'] = mod['ModTypeKey']['Name']
 

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -1911,6 +1911,10 @@ specification = Specification({
                 name='Flag1',
                 type='bool',
             ),
+            Field(
+                name='NotOnAtlas',
+                type='bool',
+            ),
         ),
     ),
     'AtlasNodeDefinition.dat': File(
@@ -14428,6 +14432,10 @@ specification = Specification({
                 name='ArchnemesisTier',
                 type='int',
             ),
+            Field(
+                name='SentinelTier',
+                type='int',
+            ),
         ),
     ),
     'MapStatConditions.dat': File(
@@ -16721,6 +16729,18 @@ specification = Specification({
             ),
             Field(
                 name='Flag1',
+                type='bool',
+            ),
+            Field(
+                name='Keys0',
+                type='ref|list|ulong',
+            ),
+            Field(
+                name='Flag2',
+                type='bool',
+            ),
+            Field(
+                name='Flag3',
                 type='bool',
             ),
         ),

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -1107,11 +1107,6 @@ specification = Specification({
                 type='bool',
             ),
             Field(
-                name='IntId',
-                type='int',
-                unique=True,
-            ),
-            Field(
                 name='Flag2',
                 type='bool',
             ),
@@ -1126,6 +1121,14 @@ specification = Specification({
                 type='ref|string',
                 key='Animation.dat',
                 key_id='Id',
+            ),
+            Field(
+                name='Flag3',
+                type='bool',
+            ),
+            Field(
+                name='Key0',
+                type='ulong',
             ),
         ),
     ),
@@ -9105,6 +9108,112 @@ specification = Specification({
             ),
         ),
     ),
+    'GrantedEffectStatSets.dat': File(
+        fields=(
+            Field(
+                name='Id',
+                type='ref|string',
+                unique=True,
+            ),
+            Field(
+                name='ImplicitStats',
+                type='ref|list|ulong',
+                key='Stats.dat',
+            ),
+            Field(
+                name='ConstantStats',
+                type='ref|list|ulong',
+                key='Stats.dat',
+            ),
+            Field(
+                name='ConstantStatsValues',
+                type='ref|list|int',
+            ),
+            Field(
+                name='BaseEffectiveness',
+                type='float',
+            ),
+            Field(
+                name='IncrementalEffectiveness',
+                type='float',
+            ),
+        ),
+    ),
+    'GrantedEffectStatSetsPerLevel.dat': File(
+        fields=(
+            Field(
+                name='StatSet',
+                type='ulong',
+                key='GrantedEffectStatSets.dat',
+            ),
+            Field(
+                name='GemLevel',
+                type='int',
+            ),
+            Field(
+                name='PlayerLevelReq',
+                type='int',
+            ),
+            Field(
+                name='SpellCritChance',
+                type='int',
+            ),
+            Field(
+                name='AttackCritChance',
+                type='int',
+            ),
+            Field(
+                name='BaseMultiplier',
+                type='int',
+            ),
+            Field(
+                name='DamageEffectiveness',
+                type='int',
+            ),
+            Field(
+                name='AdditionalFlags',
+                type='ref|list|ulong',
+                key='Stats.dat',
+            ),
+            Field(
+                name='FloatStats',
+                type='ref|list|ulong',
+                key='Stats.dat',
+            ),
+            Field(
+                name='InterpolationBases',
+                type='ref|list|ulong',
+                key='Stats.dat',
+            ),
+            Field(
+                name='AdditionalStats',
+                type='ref|list|ulong',
+                key='Stats.dat',
+            ),
+            Field(
+                name='StatInterpolations',
+                type='ref|list|int',
+                enum='STAT_INTERPOLATION_TYPES',
+            ),
+            Field(
+                name='FloatStatsValues',
+                type='ref|list|float',
+            ),
+            Field(
+                name='BaseResolvedValues',
+                type='ref|list|int',
+            ),
+            Field(
+                name='AdditionalStatsValues',
+                type='ref|list|int',
+            ),
+            Field(
+                name='GrantedEffects',
+                type='ref|list|ulong',
+                key='GrantedEffects.dat',
+            ),
+        ),
+    ),
     'GrantedEffects.dat': File(
         fields=(
             Field(
@@ -9123,19 +9232,11 @@ specification = Specification({
                 description='This support gem only supports active skills with at least one of these types',
             ),
             Field(
-                name='BaseEffectiveness',
-                type='float',
-            ),
-            Field(
-                name='IncrementalEffectiveness',
-                type='float',
-            ),
-            Field(
                 name='SupportGemLetter',
                 type='ref|string',
             ),
             Field(
-                name='Unknown0',
+                name='Attribute',
                 type='int',
             ),
             Field(
@@ -9156,7 +9257,7 @@ specification = Specification({
                 description='This support gem only supports active skills that come from gem items',
             ),
             Field(
-                name='Unknown1',
+                name='Unknown0',
                 type='int',
             ),
             Field(
@@ -9164,11 +9265,11 @@ specification = Specification({
                 type='ref|list|int',
             ),
             Field(
-                name='Flag0',
+                name='CannotBeSupported',
                 type='bool',
             ),
             Field(
-                name='Unknown2',
+                name='Unknown1',
                 type='int',
             ),
             Field(
@@ -9176,25 +9277,27 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='ActiveSkillsKey',
+                name='ActiveSkill',
                 type='ulong',
                 key='ActiveSkills.dat',
             ),
             Field(
-                name='Flag1',
+                name='IgnoreMinionTypes',
                 type='bool',
             ),
             Field(
-                name='Flag2',
+                name='Flag0',
                 type='bool',
             ),
             Field(
-                name='Data1',
-                type='ref|list|int',
+                name='AddedMinionActiveSkillTypes',
+                type='ref|list|ulong',
+                key='ActiveSkillType.dat',
             ),
             Field(
-                name='Key0',
+                name='Animation',
                 type='ulong',
+                key='Animation.dat',
             ),
             Field(
                 name='MultiPartAchievement',
@@ -9202,18 +9305,22 @@ specification = Specification({
                 key='MultiPartAchievements.dat',
             ),
             Field(
-                name='Flag3',
+                name='Flag1',
                 type='bool',
             ),
             Field(
-                name='ItemClasses',
+                name='SupportWeaponRestrictions',
                 type='ref|list|ulong',
                 key='ItemClasses.dat',
             ),
             Field(
-                name='GrantedEffectsKey',
+                name='RegularVariant',
                 type='ref|generic',
                 key='GrantedEffects.dat',
+            ),
+            Field(
+                name='Unknown2',
+                type='int',
             ),
             Field(
                 name='Unknown3',
@@ -9224,19 +9331,24 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Unknown5',
-                type='int',
+                name='Flag2',
+                type='bool',
             ),
             Field(
-                name='Flag4',
-                type='bool',
+                name='StatSet',
+                type='ulong',
+                key='GrantedEffectStatSets.dat',
+            ),
+            Field(
+                name='Keys0',
+                type='ref|list|ulong',
             ),
         ),
     ),
     'GrantedEffectsPerLevel.dat': File(
         fields=(
             Field(
-                name='GrantedEffectsKey',
+                name='GrantedEffect',
                 type='ulong',
                 key='GrantedEffects.dat',
             ),
@@ -9245,111 +9357,12 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='StatsKeys',
-                type='ref|list|ulong',
-                key='Stats.dat',
-            ),
-            Field(
-                name='Stat1Float',
-                type='float',
-            ),
-            Field(
-                name='Stat2Float',
-                type='float',
-            ),
-            Field(
-                name='Stat3Float',
-                type='float',
-            ),
-            Field(
-                name='Stat4Float',
-                type='float',
-            ),
-            Field(
-                name='Stat5Float',
-                type='float',
-            ),
-            Field(
-                name='Stat6Float',
-                type='float',
-            ),
-            Field(
-                name='Stat7Float',
-                type='float',
-            ),
-            Field(
-                name='Stat8Float',
-                type='float',
-            ),
-            Field(
-                name='Stat9Float',
-                type='float',
-            ),
-            Field(
-                name='EffectivenessCostConstantsKeys',
-                type='ref|list|ulong',
-                key='EffectivenessCostConstants.dat',
-            ),
-            Field(
-                name='Stat1Value',
+                name='PlayerLevelReq',
                 type='int',
             ),
             Field(
-                name='Stat2Value',
+                name='CostMultiplier',
                 type='int',
-            ),
-            Field(
-                name='Stat3Value',
-                type='int',
-            ),
-            Field(
-                name='Stat4Value',
-                type='int',
-            ),
-            Field(
-                name='Stat5Value',
-                type='int',
-            ),
-            Field(
-                name='Stat6Value',
-                type='int',
-            ),
-            Field(
-                name='Stat7Value',
-                type='int',
-            ),
-            Field(
-                name='Stat8Value',
-                type='int',
-            ),
-            Field(
-                name='Stat9Value',
-                type='int',
-            ),
-            Field(
-                name='LevelRequirement',
-                type='int',
-            ),
-            Field(
-                name='ManaMultiplier',
-                type='int',
-            ),
-            Field(
-                name='LevelRequirement2',
-                type='int',
-            ),
-            Field(
-                name='LevelRequirement3',
-                type='int',
-            ),
-            Field(
-                name='CriticalStrikeChance',
-                type='int',
-            ),
-            Field(
-                name='DamageEffectiveness',
-                type='int',
-                description='Damage effectiveness based on 0 = 100%',
             ),
             Field(
                 name='StoredUses',
@@ -9362,16 +9375,6 @@ specification = Specification({
             Field(
                 name='CooldownBypassType',
                 type='int',
-            ),
-            Field(
-                name='StatsKeys2',
-                type='ref|list|ulong',
-                key='Stats.dat',
-                description='Used with a value of one',
-            ),
-            Field(
-                name='Flag0',
-                type='bool',
             ),
             Field(
                 name='VaalSouls',
@@ -9390,34 +9393,7 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='DamageMultiplier',
-                type='int',
-                description='Damage multiplier in 1/10000 for attack skills',
-            ),
-            Field(
-                name='Unknown1',
-                type='int',
-            ),
-            Field(
-                name='ArtVariation',
-                type='int',
-            ),
-            Field(
-                name='StatInterpolationTypesKeys',
-                type='ref|list|int',
-                enum='STAT_INTERPOLATION_TYPES',
-            ),
-            Field(
-                name='Unknown2',
-                type='int',
-            ),
-            Field(
-                name='VaalSoulGainPreventionTime',
-                type='int',
-                description='Time in milliseconds',
-            ),
-            Field(
-                name='BaseDuration',
+                name='SoulGainPreventionDuration',
                 type='int',
             ),
             Field(
@@ -9425,7 +9401,7 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Unknown3',
+                name='Unknown1',
                 type='int',
             ),
             Field(
@@ -9433,7 +9409,7 @@ specification = Specification({
                 type='ref|list|int',
             ),
             Field(
-                name='CostTypesKeys',
+                name='CostTypes',
                 type='ref|list|ulong',
                 key='CostTypes.dat',
             ),
@@ -9454,35 +9430,14 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Unknown4',
-                type='int',
-            ),
-            Field(
-                name='AttackCritChance',
-                type='int',
-            ),
-            Field(
                 name='AttackTime',
                 type='int',
             ),
         ),
         virtual_fields=(
             VirtualField(
-                name='StatValues',
-                fields=('Stat1Value', 'Stat2Value', 'Stat3Value', 'Stat4Value', 'Stat5Value', 'Stat6Value', 'Stat7Value', 'Stat8Value', 'Stat9Value'),
-            ),
-            VirtualField(
-                name='StatFloats',
-                fields=('Stat1Float', 'Stat2Float', 'Stat3Float', 'Stat4Float', 'Stat5Float', 'Stat6Float', 'Stat7Float', 'Stat8Float'),
-            ),
-            VirtualField(
-                name='Stats',
-                fields=('StatsKeys', 'StatValues'),
-                zip=True,
-            ),
-            VirtualField(
                 name='Costs',
-                fields=('CostTypesKeys', 'CostAmounts'),
+                fields=('CostTypes', 'CostAmounts'),
                 zip=True,
             ),
         ),
@@ -19452,11 +19407,11 @@ specification = Specification({
             ),
             Field(
                 name='Unknown12',
-                type='int',
+                type='ref|list|int',
             ),
             Field(
-                name='Unknown13',
-                type='int',
+                name='String0',
+                type='ref|string',
             ),
         ),
     ),

--- a/PyPoE/poe/file/specification/fields.py
+++ b/PyPoE/poe/file/specification/fields.py
@@ -409,8 +409,8 @@ class File:
         else:
             starting_fields_length = len(fields)
             fields = OrderedDict(((field.name, field) for field in fields))
-        if starting_fields_length != len(fields):
-            raise(ValueError("Field names must be unique within each file definition."))
+        assert starting_fields_length == len(fields), "Field names must be unique within each file definition."
+        
         self.fields = fields
         if virtual_fields is None:
             virtual_fields = OrderedDict()

--- a/PyPoE/poe/file/specification/fields.py
+++ b/PyPoE/poe/file/specification/fields.py
@@ -403,10 +403,14 @@ class File:
             OrderedDict containing the field name as key and a
             :class:`VirtualField` instance as value
         """
+        starting_fields_length = 0
         if fields is None:
             fields = OrderedDict()
         else:
+            starting_fields_length = len(fields)
             fields = OrderedDict(((field.name, field) for field in fields))
+        if starting_fields_length != len(fields):
+            raise(ValueError("Field names must be unique within each file definition."))
         self.fields = fields
         if virtual_fields is None:
             virtual_fields = OrderedDict()


### PR DESCRIPTION
# Abstract

I made required updates so that the Sentinel Map Series could be exported to the wiki.  
I also added a validation check to ensure you haven't added two fields with the same name to a .dat spec. Before if you did this, it would ignore the latter one and keep giving you the same .dat spec size mismatch error even though you tried to fix it.

# Action Taken

I updated the .dat specs and the map series list in PyPoE.

# Caveats

There are some assorted other .dat spec updates included in here, and one of them renames GrantedEffectsKey to GrantedEffect in GrantedEffectsPerLevel.dat, which will break skill gem exporting. However, skill gem exporting is very broken in this branch with and without this PR due to GGG's changes midway through 3.18.  
I have [another branch](https://github.com/angelic-knight/PyPoE/tree/patches-double-skill-gems) that fixes skill gem exporting.

# FAO

@pm5k any thoughts on what kind of error should get thrown in fields.py?
