### PR TITLE
Supporting Mod Families (and More Spec Updates)

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/mods.py
+++ b/PyPoE/cli/exporter/wiki/parsers/mods.py
@@ -68,6 +68,7 @@ class OutOfBoundsWarning(UserWarning):
 class ModWikiCondition(WikiCondition):
     COPY_KEYS = (
         'tier_text',
+        'mod_group',
     )
 
     NAME = 'Mod'
@@ -220,7 +221,7 @@ class ModParser(BaseParser):
 
             for k in (
                 ('Id', 'id'),
-                ('CorrectGroup', 'mod_group'),
+                #('ModGroups', 'mod_groups'),
                 ('Domain', 'domain'),
                 ('GenerationType', 'generation_type'),
                 ('Level', 'required_level'),
@@ -236,6 +237,9 @@ class ModParser(BaseParser):
                     return hstr if parameter == 'MS' else ''
 
                 data['name'] = root.handle_tags({'if': handler, 'elif': handler})
+
+            if mod['ModGroups']:
+                data['mod_groups'] = ', '.join([mod_fam['Id'] for mod_fam in mod['ModGroups']])
 
             # TODO: need to look into this before completely removing it.
 

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -6267,7 +6267,7 @@ specification = Specification({
                 type='int',
             ),
             Field( 
-                name='EndlessDelveMonsterLevel', #This is pobably endless delve mosnter level scaling.
+                name='EndlessDelveMonsterLevel', #This is pobably endless delve monster level scaling.
                 type='int',
             ),
         ),
@@ -7074,19 +7074,15 @@ specification = Specification({
             ),
             Field(
                 name='Unknown0',
-                type='int',
+                type='ulong',
             ),
             Field(
                 name='Unknown1',
-                type='int',
+                type='ulong',
             ),
             Field(
-                name='Unknown2',
-                type='int',
-            ),
-            Field(
-                name='Unknown3',
-                type='int',
+                name='List',
+                type='ref|list|ulong',
             ),
             Field(
                 name='EnvironmentTransitionsKey',
@@ -11672,18 +11668,6 @@ specification = Specification({
                 type='bool',
             ),
             Field(
-                name='Unknown0',
-                type='int',
-            ),
-            Field(
-                name='Unknown1',
-                type='int',
-            ),
-            Field(
-                name='Unknown2',
-                type='int',
-            ),
-            Field(
                 name='InheritsFrom',
                 type='ref|string',
                 file_path=True,
@@ -11715,6 +11699,18 @@ specification = Specification({
                 type='ulong',
                 #key='HideoutDoodadCategory.dat',
             ),
+            Field(
+                name='Unknown0',
+                type='int'
+            ),
+            Field(
+                name='Flag2',
+                type='bool',
+            ),
+            Field(
+                name='Key1',
+                type='ulong',
+            ),
         ),
     ),
     'HideoutNPCs.dat': File(
@@ -11739,23 +11735,23 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Unknown0',
-                type='int',
+                name='Key0',
+                type='ulong',
+            ),
+            Field(
+                name='Key1',
+                type='ulong',
             ),
             Field(
                 name='Unknown1',
                 type='int',
             ),
             Field(
-                name='Unknown2',
-                type='int',
-            ),
-            Field(
-                name='Key0',
+                name='Key2',
                 type='ulong',
             ),
             Field(
-                name='Unknown3',
+                name='Unknown2',
                 type='int',
             ),
             Field(
@@ -11763,7 +11759,7 @@ specification = Specification({
                 type='bool',
             ),
             Field(
-                name='Key1',
+                name='Key3',
                 type='ulong',
             ),
         ),
@@ -17487,6 +17483,10 @@ specification = Specification({
                 name='Unknown38',
                 type='int',
             ),
+            Field(
+                name='Unknown39',
+                type='int',
+            ),
         ),
     ),
     'MoveDaemon.dat': File(
@@ -17809,6 +17809,14 @@ specification = Specification({
             ),
             Field(
                 name='Unknown3',
+                type='int',
+            ),
+            Field(
+                name='Unknown4',
+                type='int',
+            ),
+            Field(
+                name='Unknown5',
                 type='int',
             ),
         ),
@@ -18379,8 +18387,8 @@ specification = Specification({
                 file_ext='.ot, .otc',
             ),
             Field(
-                name='Unknown0',
-                type='int',
+                name='Key0',
+                type='ulong',
             ),
             Field(
                 name='NPCMasterKey',
@@ -23538,7 +23546,7 @@ specification = Specification({
             ),
             Field(
                 name='Unknown2',
-                type='int',
+                type='ulong',
             ),
             Field(
                 name='Data0',
@@ -23564,11 +23572,11 @@ specification = Specification({
             ),
             Field(
                 name='Unknown5',
-                type='int',
+                type='ulong',
             ),
             Field(
                 name='Unknown6',
-                type='int',
+                type='ulong',
             ),
             Field(
                 name='Bosses_MonsterVarietiesKeys',

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -15687,6 +15687,15 @@ specification = Specification({
             ),
         ),
     ),
+    'ModFamily.dat': File(
+        fields=(
+            Field(
+                name='Id',
+                type='ref|string',
+                unique=True,
+            ),
+        ),
+    ),
     'ModSellPriceTypes.dat': File(
         fields=(
             Field(
@@ -15788,8 +15797,9 @@ specification = Specification({
                 enum='MOD_GENERATION_TYPE',
             ),
             Field(
-                name='Keys0',
+                name='ModGroups',
                 type='ref|list|ulong',
+                key='ModFamily.dat'
             ),
             Field(
                 name='Stat1Min',


### PR DESCRIPTION
# Abstract

I added support for exporting mods using the new mod families.  
The previous `mod_group` parameter was maintained.

# Action Taken
Spec updates, introduction of `mod_groups` exporting for the new mod families concept.

# Caveats
I haven't tested this recently. It worked... in September or something.

# FAO

@zao @pm5k @acbeaumo 