### PR TITLE
Define stat translations and mod domain for templar relics

### DIFF
--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -699,7 +699,7 @@ class MOD_DOMAIN(IntEnumOverride):
     CHEST = 4
     AREA = 5
     UNKNOWN1 = 6
-    UNKNOWN2 = 7
+    TEMPLAR_RELIC = 7
     UNKNOWN3 = 8
     CRAFTED = 9
     # Corruptions, item limits, jewel mods, other stuff?

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -16086,10 +16086,6 @@ specification = Specification({
                 key='Tags.dat',
             ),
             Field(
-                name='Unknown1',
-                type='int',
-            ),
-            Field(
                 name='Flag1',
                 type='bool',
             ),
@@ -16154,6 +16150,10 @@ specification = Specification({
                 type='int',
             ),
             Field(
+                name='Unknown17',
+                type='int',
+            ),
+            Field(
                 name='BuffTemplate',
                 type='ref|out',
                 key='BuffTemplates.dat',
@@ -16172,7 +16172,7 @@ specification = Specification({
                 type='ref|list|ref|out',
             ),
             Field(
-                name='Unknown17',
+                name='Unknown18',
                 type='int',
             ),
             Field(

--- a/PyPoE/poe/sim/mods.py
+++ b/PyPoE/poe/sim/mods.py
@@ -82,6 +82,7 @@ _translation_map = {
     MOD_DOMAIN.HEIST_NPC: 'heist_equipment_stat_descriptions.txt',
     MOD_DOMAIN.PRIMORDIAL_ALTAR: 'primordial_altar_stat_descriptions.txt',
     MOD_DOMAIN.SENTINEL: 'sentinel_stat_descriptions.txt',
+    MOD_DOMAIN.TEMPLAR_RELIC: 'sanctum_relic_stat_descriptions.txt',
 }
 
 # =============================================================================


### PR DESCRIPTION
# Abstract

This PR addresses feedback that the mods on templar relics do not have their mod text exported to the wiki. As their stat translations are in a new file that needs to be explicitly mapped.

# Action Taken

When a mod domain comes with a new stat translation text file it needs to be explicitly mapped to reference that file.
Templar relics seem to use a previously unknown mod domain so we also name that domain.
Gratuitous spec update for Mods included as some unused fields were in the wrong order.

# Caveats

Ran a test export for the mod domain locally with Steam build 10188614 (3.20.1 207952) and the stat text now seem to be filled out properly.

# FAO

n/a