### PR TITLE
Reverted parser to use template:il

### DIFF
--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1716,7 +1716,7 @@ class TagHandler:
         :func:`parse_description_tags`
     """
 
-    _IL_FORMAT = '{{iil|%s}}'
+    _IL_FORMAT = '{{il|%s}}'
     _C_FORMAT = '{{c|%s|%s}}'
 
     def __init__(self, rr):


### PR DESCRIPTION
# Abstract

Reverted the changes from #8 to parser.py to use `il` template.

# Action Taken

Reverted change from #8 

# Caveats

- 

# FAO

-
