### PR TITLE
Fix parser template

### DIFF
--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1716,7 +1716,7 @@ class TagHandler:
         :func:`parse_description_tags`
     """
 
-    _IL_FORMAT = '{{il|%s}}'
+    _IL_FORMAT = '{{il|html=|%s}}'
     _C_FORMAT = '{{c|%s|%s}}'
 
     def __init__(self, rr):


### PR DESCRIPTION
Small update to the parser template to prevent it from outputting the item infobox html.