### PR TITLE
Process and append binary stat keys for buffs

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -337,9 +337,18 @@ class PassiveSkillParser(parser.BaseParser):
 
             # For now this is being added to the stat text
             for ps_buff in passive['PassiveSkillBuffsKeys']:
-                stat_ids = [stat['Id'] for stat in
-                            ps_buff['BuffDefinitionsKey']['StatsKeys']]
+                buff_defs = ps_buff['BuffDefinitionsKey']
+                stat_ids = [stat['Id'] for stat in buff_defs['StatsKeys']]
                 values = ps_buff['Buff_StatValues']
+
+                # There's an additional set of stats for buffs and auras that do not have
+                # an explicit value associated with them but should be treated as if they
+                # had a value of 1.
+                binary_stat_ids = [stat['Id'] for stat in buff_defs['Binary_StatsKeys']]
+                for id in binary_stat_ids:
+                    stat_ids.append(id)
+                    values.append(1)
+
                 #if passive['Id'] == 'AscendancyChampion7':
                 #    index = stat_ids.index('damage_taken_+%_from_hits')
                 #    del stat_ids[index]

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -3923,8 +3923,9 @@ specification = Specification({
                 type='ref|list|ref|out',
             ),
             Field(
-                name='Keys2',
+                name='Binary_StatsKeys',
                 type='ref|list|ref|out',
+                key='Stats.dat',
             ),
             Field(
                 name='Keys3',


### PR DESCRIPTION
# Abstract

Some passive nodes have buff stats with no associated value, this adds machinery for a previously unknown column that provides their effects.

# Action Taken

There's a field in buff definitions for stats that should have an implied 1 as value. These are now considered and added to the list of buff stats in passive exports.

# Caveats

Some wording changes may arise from this and debuff effects intended for enemies end up as stats in the data, for example:
```diff
02:56:53 All conditions met on page "Passive Skill:AscendancyTrickster12". Editing.
--- Wiki
+++ Export
@@ -2,11 +2,14 @@
 |id                                  = AscendancyTrickster12
 |int_id                              = 23225
 |name                                = One Step Ahead
+|buff_id                             = trickster_nearby_enemy_action_speed
 |ascendancy_class                    = Trickster
 |is_notable                          = True
 |icon                                = OneStepAheadTrickster (Trickster)
 |stat1_id                            = action_speed_is_at_least_108%
 |stat1_value                         = 1
-|stat_text                           = Your [[Action Speed]] is at least 108% of base value<br>Nearby enemy monsters' [[Action Speed]] is at most 92% of base value
+|stat_text                           = Your Action Speed is at least 108% of base value<br>Nearby Enemy Monsters' Action Speed is at most 92% of base value
+|stat2_id                            = action_speed_is_at_most_92%
+|stat2_value                         = 1
 |connections                         = AscendancyTrickster9
 }}
 ```

# FAO

@acbeaumo @blcksvn @Journeytojah