### PR TITLE
Update some specifications for 3.20.3

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -33,7 +33,7 @@ See PyPoE/LICENSE
 
 # Python
 import os
-from typing import Union
+from typing import List, Tuple, Union
 import warnings
 import traceback
 from collections import OrderedDict, defaultdict
@@ -330,7 +330,7 @@ class SkillParserShared(parser.BaseParser):
             infobox[prefix + 'id'] = val[0]
             infobox[prefix + 'value'] = val[1]
 
-    def _translate_stats(self, stats, values: Union[list[int], list[tuple[int, int]]], trans_file: TranslationFile, data: defaultdict, stat_order: defaultdict) -> OrderedDict:
+    def _translate_stats(self, stats, values: Union[List[int], List[Tuple[int, int]]], trans_file: TranslationFile, data: defaultdict, stat_order: defaultdict) -> OrderedDict:
         stats_output = OrderedDict()
 
         trans_rslt = trans_file.get_translation(

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -5472,17 +5472,19 @@ specification = Specification({
                 type='ref|out',
             ),
             Field(
-                name='AchievementItemsKeys',
+                name='ModifyMapsAchievements',
                 type='ref|list|ref|out',
                 key='AchievementItems.dat',
             ),
             Field(
-                name='Keys1',
+                name='ModifyContractsAchievements',
                 type='ref|list|ref|out',
+                key='AchievementItems.dat',
             ),
             Field(
-                name='Keys2',
+                name='CombineAchievements',
                 type='ref|list|ref|out',
+                key='AchievementItems.dat',
             ),
             Field(
                 name='Unknown1',
@@ -5493,16 +5495,21 @@ specification = Specification({
                 type='ref|list|int',
             ),
             Field(
-                name='Key2',
+                name='ShopTagKey',
                 type='ref|out',
+                key='ShopTag.dat',
             ),
             Field(
-                name='Flag1',
+                name='IsHardmode',
                 type='bool',
             ),
             Field(
-                name='Unknown2',
+                name='DescriptionHardmode',
                 type='ref|string',
+            ),
+            Field(
+                name='IsGold',
+                type='bool',
             ),
         ),
     ),
@@ -6057,6 +6064,14 @@ specification = Specification({
             Field(
                 name='Flag1',
                 type='bool',
+            ),
+            Field(
+                name='Unknown0',
+                type='ref|list|int',
+            ),
+            Field(
+                name='Unknown2',
+                type='ref|list|int',
             ),
         ),
     ),
@@ -18531,11 +18546,6 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='NPCShop',
-                type='ref|out',
-                key='NPCShop.dat',
-            ),
-            Field(
                 name='NPCAudios1',
                 type='ref|list|ref|out',
                 key='NPCAudio.dat',
@@ -18565,12 +18575,16 @@ specification = Specification({
                 key='NPCDialogueStyles.dat',
             ),
             Field(
+                name='Flag0',
+                type='bool',
+            ),
+            Field(
                 name='Unknown4',
                 type='ref|out',
             ),
             Field(
-                name='Flag0',
-                type='bool',
+                name='Gender',
+                type='ref|string',
             ),
         ),
     ),
@@ -20770,6 +20784,32 @@ specification = Specification({
                 name='Id',
                 type='ref|string',
                 unique=True,
+            ),
+        ),
+    ),
+    'ShopTag.dat': File(
+        fields=(
+            Field(
+                name='Id',
+                type='ref|string',
+            ),
+            Field(
+                name='Name',
+                type='ref|string',
+            ),
+            Field(
+                name='IsCategory',
+                type='bool',
+            ),
+            Field(
+                name='Category',
+                type='ref|self',
+                key='ShopTag.dat',
+            ),
+            Field(
+                name='SkillGem',
+                type='ref|list|ref|out',
+                key='BaseItemTypes.dat',
             ),
         ),
     ),

--- a/PyPoE/poe/file/specification/fields.py
+++ b/PyPoE/poe/file/specification/fields.py
@@ -511,7 +511,7 @@ class Field(_Common, ReprMixin):
 
     Variable/Pointer types:
         ref|<other>
-            32 bit value, unsigned
+            32 or 64 bit value, unsigned
 
             a pointer to the data section
         ref|list|<other>


### PR DESCRIPTION
Fixes lua exports for bestiary, blight, and pantheon

# Abstract

Updates a few specifications based on 3.20.3 to fix some of the broken lua exports.

# Action Taken

In addition to updating some specs, a spec for `ShopTag.dat` was added.

I also fixed some type hints that use 3.9+ syntax to work in 3.7, since the README still recommends it. Those'll probably need to be fixed in any PR that updates the targeted Python version.

# Caveats

Not all the failing lua exports are addressed in this PR. Some are failing due to missing .dat64 files in the latest ggpk and I skipped over these to focus on ones with existing specifications that needed updating.

I'm not 100% on the purpose of the new `bool` in CurrencyItems.dat64, but it's false for every row except for what looks like Gold, so I've named it `IsGold`.

# FAQ

Probably @zao
