### PR TITLE
Add support for new hash algorithm

### DIFF
--- a/PyPoE/poe/file/bundle.py
+++ b/PyPoE/poe/file/bundle.py
@@ -67,10 +67,10 @@ from typing import List, Union, Dict, Tuple
 
 # 3rd party
 from fnvhash import fnv1a_64
-from mmhash2 import murmurhash64a
 import ooz
 
 # self
+from PyPoE.shared.murmur2 import murmur2_64a
 from PyPoE.shared.mixins import ReprMixin
 from PyPoE.shared.decorators import doc
 from PyPoE.poe.file.shared import AbstractFileReadOnly
@@ -391,7 +391,7 @@ def _hash_path_3_21_2(path, seed):
     if path.endswith(b'/'):
         path = path.strip(b'/')
     path = path.lower()
-    return murmurhash64a(path, seed)
+    return murmur2_64a(path, seed)
 
 
 class Index(Bundle):

--- a/PyPoE/poe/file/bundle.py
+++ b/PyPoE/poe/file/bundle.py
@@ -541,13 +541,8 @@ class Index(Bundle):
                 h ^= h >> 47
                 h = (h * 0x5F7A0EA7E59B19BD) % 2**64
                 h ^= h >> 47
-                for cand in dir_iter:
-                    if len(cand.paths) > 0:
-                        dir = cand.paths[0].rsplit('/', 1)[0]
-                        if _hash_path_3_21_2(dir, h) == cand.hash:
-                            self.hash_algorithm = HASH_ALGORITHM.MURMURHASH64A
-                            self.hash_seed = h
-                        break
+                self.hash_algorithm = HASH_ALGORITHM.MURMURHASH64A
+                self.hash_seed = h
 
 
     def _make_paths(self, raw: bytes) -> List[bytes]:

--- a/PyPoE/poe/file/shared/__init__.py
+++ b/PyPoE/poe/file/shared/__init__.py
@@ -377,7 +377,7 @@ class AbstractFileSystemNode(ReprMixin):
                 return obj
 
             for child in obj.children.values():
-                if child.name == partial:
+                if child.name.lower() == partial.lower():
                     obj = child
                     break
             else:

--- a/PyPoE/shared/murmur2.py
+++ b/PyPoE/shared/murmur2.py
@@ -94,3 +94,64 @@ def murmur2_32(byte_data, seed=DEFAULT_SEED):
     h = h ^ (h >> 15 & int32)
 
     return h
+
+
+def bytes_to_long(bytes):
+    assert len(bytes) == 8
+    return sum((b << (k * 8) for k, b in enumerate(bytes)))
+
+# https://gist.github.com/wey-gu/5543c33987c0a5e8f7474b9b80cd36aa
+def murmur2_64a(data, seed = 0x1337b33f):
+
+    import ctypes
+
+    m = ctypes.c_uint64(0xc6a4a7935bd1e995).value
+
+    r = ctypes.c_uint32(47).value
+
+    MASK = ctypes.c_uint64(2 ** 64 - 1).value
+
+    data_as_bytes = bytearray(data)
+
+    seed = ctypes.c_uint64(seed).value
+
+    h = seed ^ ((m * len(data_as_bytes)) & MASK)
+
+    off = int(len(data_as_bytes)/8)*8
+    for ll in range(0, off, 8):
+        k = bytes_to_long(data_as_bytes[ll:ll + 8])
+        k = (k * m) & MASK
+        k = k ^ ((k >> r) & MASK)
+        k = (k * m) & MASK
+        h = (h ^ k)
+        h = (h * m) & MASK
+
+    l = len(data_as_bytes) & 7
+
+    if l >= 7:
+        h = (h ^ (data_as_bytes[off+6] << 48))
+
+    if l >= 6:
+        h = (h ^ (data_as_bytes[off+5] << 40))
+
+    if l >= 5:
+        h = (h ^ (data_as_bytes[off+4] << 32))
+
+    if l >= 4:
+        h = (h ^ (data_as_bytes[off+3] << 24))
+
+    if l >= 3:
+        h = (h ^ (data_as_bytes[off+2] << 16))
+
+    if l >= 2:
+        h = (h ^ (data_as_bytes[off+1] << 8))
+
+    if l >= 1:
+        h = (h ^ data_as_bytes[off])
+        h = (h * m) & MASK
+
+    h = h ^ ((h >> r) & MASK)
+    h = (h * m) & MASK
+    h = h ^ ((h >> r) & MASK)
+
+    return ctypes.c_uint64(h).value

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
-    install_requires=['configobj', 'brotli', 'fnvhash', 'pyooz'],
+    install_requires=['configobj', 'brotli', 'fnvhash', 'mmhash2', 'pyooz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
-    install_requires=['configobj', 'brotli', 'fnvhash', 'mmhash2', 'pyooz'],
+    install_requires=['configobj', 'brotli', 'fnvhash', 'pyooz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
# Abstract

In Path of Exile 3.21.2 the method of computing the hash for paths has changed significantly where the hash algorithm went from FNV1A64 to MurmurHash64A with a custom seed. The logic transforming pathnames before hashing also changed with the new file and directory paths always being lowercase, without any trailing slashes and without the old suffix of `++`.

# Action Taken

New logic for hashing pathnames was added while retaining the old way for legacy data. The algorithm and seed is auto-detected from the hash of the root directory as it hashes a known zero-length string. The hash algorithm is in pure Python and lifted from https://github.com/lvlvllvlvllvlvl/PyPoE/commit/f5c4263408b79c2c74029b45254c2e5a385d8c46 .

# Caveats

While the new seed is known in advance this code derives it mathematically from the directory entries present in the index file to make it more resilient against future seed changes. This has a small computational cost when opening the index on program startup.

~This change introduces a new dependency on `mmhash2` to compute the new hashes - existing installations need to re-run `pip install -e .` to obtain and install the new dependency.~

# FAO