### PR TITLE
add attack time

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -157,7 +157,7 @@ class SkillParserShared(parser.BaseParser):
         'Level', 'PlayerLevelReq', 'CostMultiplier',
         'CostAmounts', 'CostTypes', 'VaalSouls', 'VaalStoredUses',
         'SoulGainPreventionDuration', 'Cooldown', 'StoredUses', 'AttackSpeedMultiplier',
-        'ManaReservationFlat', 'ManaReservationPercent', 'LifeReservationFlat', 'LifeReservationPercent',
+        'ManaReservationFlat', 'ManaReservationPercent', 'LifeReservationFlat', 'LifeReservationPercent', 'AttackTime'
     )
 
     # Fields to copy from GrantedEffectStatSetsPerLevel.dat64
@@ -267,6 +267,11 @@ class SkillParserShared(parser.BaseParser):
             'template': 'life_reservation_percent',
             'default': 0,
             'format': lambda v: '{0:n}'.format(v/100),
+        }),
+        ('AttackTime', {
+            'template': 'attack_time',
+            'default': 0,
+            'format': lambda v: '{0:n}'.format(v/1000),
         }),
     )
 


### PR DESCRIPTION
# Abstract

Add attack time (for shield skills)

# Action Taken

Attack time is in GrantedEffectsPerLevel, even though it's currently the same at every level. This change just uses the default processing for level values though, so if a future patch does add or update a skill with scaling attack time the level data should be processed automatically.

Results of applying this change can be seen at https://github.com/lvlvllvlvllvlvl/wiki-data-export/commit/8a31be2d194e529443c0abab5eb0509cbd8ed4c2

# Caveats

Changes need to be made to the wiki modules to add this field to the skill infobox. l have applied the following changes to sandbox modules:

https://www.poewiki.net/index.php?title=Module:Item2/sandbox&diff=1368582&oldid=1357882
https://www.poewiki.net/index.php?title=Module:Skill/config/sandbox&diff=1368589&oldid=1320734
https://www.poewiki.net/index.php?title=Module:Skill/sandbox&diff=1368590&oldid=1320929

however, if l [use the sandbox template](https://www.poewiki.net/index.php?title=Shield_Crush&oldid=1368594) the field appears to be using the wrong title in the infobox and l don't know why.
