### PR TITLE
Update for 3.22.0 schema changes

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -430,6 +430,7 @@ class ItemsParser(SkillParserShared):
         'Lake': '3.19.0',  # AKA Lake of Kalandra
         'Sanctum': '3.20.0',  # AKA The Forbidden Sanctum
         'Crucible': '3.21.0',
+        'Ancestral': '3.22.0',  # AKA Trial of the Ancestors
     }
 
     _IGNORE_DROP_LEVEL_CLASSES = (

--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -1045,7 +1045,7 @@ class RelationalReader(AbstractFileCache):
                 obj = other.index[key][obj]
             except KeyError:
                 msg = 'Did not find proper value for foreign key "%s" with ' \
-                      'value "%s"' % (key, obj)
+                      'value "%s" in %s' % (key, obj, other.file_name)
                 if self.raise_error_on_missing_relation:
                     raise SpecificationError(
                         SpecificationError.ERRORS.RUNTIME_MISSING_FOREIGN_KEY,

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -4098,6 +4098,10 @@ specification = Specification({
                 name='Unknown3',
                 type='ref|string',
             ),
+            Field(
+                name='Unknown4',
+                type='int',
+            ),
         ),
     ),
     'BuffVisualOrbTypes.dat': File(
@@ -4144,12 +4148,8 @@ specification = Specification({
                 type='int',
             ),
             Field(
-                name='Flag1',
-                type='bool',
-            ),
-            Field(
                 name='Unknown6',
-                type='float',
+                type='int',
             ),
             Field(
                 name='Unknown7',
@@ -4157,15 +4157,19 @@ specification = Specification({
             ),
             Field(
                 name='Unknown8',
-                type='float',
+                type='int',
             ),
             Field(
-                name='Flag2',
+                name='Flag1',
                 type='bool',
             ),
             Field(
                 name='Unknown9',
-                type='float',
+                type='int',
+            ),
+            Field(
+                name='Unknown10',
+                type='int',
             ),
         ),
     ),
@@ -5397,6 +5401,14 @@ specification = Specification({
             Field(
                 name='Key4',
                 type='ref|out',
+            ),
+            Field(
+                name='Flag1',
+                type='bool',
+            ),
+            Field(
+                name='Keys2',
+                type='ref|list|ref|out',
             ),
         ),
         virtual_fields=(
@@ -12352,6 +12364,38 @@ specification = Specification({
             ),
         ),
     ),
+    'IndexableSkillGems.dat': File(
+        fields=(
+            Field(
+                name='Index',
+                type='int',
+                unique=True,
+            ),
+            Field(
+                name='SkillGems',
+                type='ref|list|ref|out',
+                key='SkillGems.dat',
+            ),
+            Field(
+                name='Name',
+                type='ref|string',
+            ),
+            Field(
+                name='SkillGemsHardmode',
+                type='ref|list|ref|out',
+                key='SkillGems.dat',
+            ),
+            Field(
+                name='NameHardmode',
+                type='ref|string',
+            ),
+            Field(
+                name='HardmodeIndexToCanonicalIndex',
+                type='ref|self',
+                key='IndexableSkillGems.dat',
+            ),
+        ),
+    ),
     'IndexableSupportGems.dat': File(
         fields=(
             Field(
@@ -14772,6 +14816,10 @@ specification = Specification({
             ),
             Field(
                 name='CrucibleTier',
+                type='int',
+            ),
+            Field(
+                name='AncestralTier',  # AKA Ancestor
                 type='int',
             ),
         ),
@@ -24321,6 +24369,10 @@ specification = Specification({
             Field(
                 name='Unknown56',
                 type='ref|out',
+            ),
+            Field(
+                name='Unknown57',
+                type='int',
             ),
         ),
     ),

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -2174,6 +2174,13 @@ def install_data_dependant_quantifiers(relational_reader):
             relational_reader['Data/AfflictionRewardTypeVisuals.dat64'], 'Name'),
     )
 
+    TranslationQuantifier(
+        id='display_indexable_skill',
+        # handler=lambda v: relational_reader['IndexableSkillGems.dat64'][v]['Name'],
+        reverse_handler=_get_reverse_lookup_from_reader(
+            relational_reader['IndexableSkillGems.dat64'], 'Name'),
+    )
+
     # I believe this is currently not right, as the handler actually uses a value located in additionalProperties of the item, and
     # not in the mod itself. THe mod itself has min = max = 0.
     # TranslationQuantifier(
@@ -2484,6 +2491,12 @@ TranslationQuantifier(
 )
 
 TranslationQuantifier(
+    id='divide_by_twenty',
+    handler=lambda v: v/20,
+    reverse_handler=lambda v: v*20,
+)
+
+TranslationQuantifier(
     id='canonical_line',
     type=TranslationQuantifier.QuantifierTypes.STRING,
     arg_size=0,
@@ -2522,7 +2535,6 @@ TranslationQuantifier(
     id='passive_hash',
 )
 
-
 TranslationQuantifier(
     id='metamorphosis_reward_description',
 )
@@ -2530,6 +2542,10 @@ TranslationQuantifier(
 TranslationQuantifier(
     id='reminderstring',
     type=TranslationQuantifier.QuantifierTypes.STRING,
+)
+
+TranslationQuantifier(
+    id='display_indexable_skill',
 )
 
 TranslationQuantifierHandler.init()


### PR DESCRIPTION
# Abstract

Changes required to export using 3.22.0 data.

# Action Taken

Updated .dat files schema for 3.22.0.
Added "Ancestral" map series.
Support for new stat description functions:

- display_indexable_skill
- divide_by_twenty