### PR TITLE
Changes from RePoE fork

### DIFF
--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -896,7 +896,7 @@ class DatReader(ReprMixin):
         if self.specification is None:
             self.cast_size = self.table_record_length
 
-        if self.cast_size != self.table_record_length:
+        if self.cast_size > self.table_record_length:
             raise SpecificationError(
                 SpecificationError.ERRORS.RUNTIME_ROWSIZE_MISMATCH,
                 '"%(name)s": Specification row size %(spec_size)s vs real size %(cast_size)s'

--- a/PyPoE/poe/file/specification/fields.py
+++ b/PyPoE/poe/file/specification/fields.py
@@ -456,7 +456,8 @@ class File:
                     pass
 
             for item in delete_zip:
-                del self.columns_zip[item]
+                if item in self.columns_zip:
+                    del self.columns_zip[item]
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/PyPoE/poe/file/specification/generation/import_dat_schema.py
+++ b/PyPoE/poe/file/specification/generation/import_dat_schema.py
@@ -51,7 +51,7 @@ def _load_dat_schema_tables(schema_json: str):
 def _convert_tables(tables: list) -> str:
     spec = ""
     converted_tables = [_convert_table(table) for table in tables]
-    with open("template.py", "r") as f:
+    with open("template.txt", "r") as f:
         f.readline()
         for line in f:
             if line == "    # <specification>\n":
@@ -94,7 +94,7 @@ def _convert_column(table_name: str, column, name_generator: UnknownColumnNameGe
     spec = "            Field(\n"
     spec += f"                name='{column_name}',\n"
     spec += f"                type='{column_type}',\n"
-    if column.references:
+    if column.references and not column.type == "enumrow":
         spec += f"                key='{column.references.table}.dat',\n"
         if hasattr(column.references, "column"):
             spec += f"                key_id='{column.references.column}',\n"
@@ -129,8 +129,9 @@ _TYPE_MAP = {
     "string": "ref|string",
     "i32": "int",
     "f32": "float",
-    "foreignrow": "ulong",
+    "foreignrow": "ref|out",
     "row": "ref|generic",
+    "enumrow": "int",
 }
 
 

--- a/PyPoE/poe/file/specification/generation/template.txt
+++ b/PyPoE/poe/file/specification/generation/template.txt
@@ -26,7 +26,7 @@ See PyPoE/LICENSE
 # =============================================================================
 
 # 3rd-party
-from PyPoE.poe.file.specification.fields import File, Specification
+from PyPoE.poe.file.specification.fields import *
 
 # self
 
@@ -34,13 +34,10 @@ from PyPoE.poe.file.specification.fields import File, Specification
 # Globals
 # =============================================================================
 
-__all__ = [
-    "specification",
-]
+__all__ = ['specification', ]
 
-specification = Specification(
-    {
-        "SkillTotems.dat": File(),
-        # <specification>
-    }
-)
+specification = Specification({
+    'SkillTotems.dat': File(
+    ),
+    # <specification>
+})


### PR DESCRIPTION
# Abstract

Some changes l made to support running RePoE from a github action that may be useful

# Action Taken

- Allow fetching files from web urls: the poe cdn seems to be laid out such that pypoe can access its contents with minimal changes
- Treat the .dat spec as a prefix: as stated in https://github.com/Project-Path-of-Exile-Wiki/PyPoE/issues/79, additional columns added after the last valid column can safely be ignored
- Fix specification generation: the code to generate a specification from the poe-tool-dev json schema was outdated

# Caveats

- l don't know if the cdn file layout is documented; l assume it could stop working at any moment. It's been running fine since January though.
- spec generation isn't relevant to the wiki version, as the specification has been maintained by hand and has diverged from the json schema somewhat.
