### PR TITLE
Replace internal newlines in tattoo stat text

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2627,7 +2627,7 @@ class ItemsParser(SkillParserShared):
                 full_result=True,
                 lang=self._language,
             )
-            lines = tr.lines
+            lines = [" ".join(line.splitlines()) for line in tr.lines]
             infobox["tattoo_stat_text"] = "\n".join(lines)
             if override["Effect"]:
                 skill = override["Effect"]["GrantedEffect"]


### PR DESCRIPTION
# Abstract

Improve display of tattoos with multiline stat text

# Action Taken

When there are newlines within the text of a single stat granted by a tattoo, replace them with a space. This improves the display of tattoos with long single stats, such as Loyalty Tattoo of Kahutoroa, without affecting tattoos that grant multiple stats, such as https://www.poewiki.net/wiki/Honoured_Tattoo_of_the_Storm.
![image](https://github.com/Project-Path-of-Exile-Wiki/PyPoE/assets/119665497/cbe52939-5d5a-4d81-a021-0322f54307c3)

# Caveats

This only addresses stat text for tattoos specifically. There doesn't seem to be a general one-size fits-all solution that could be applied globally, so the specific case that was reported has been changed.
