### PR TITLE
Pr/mod stats

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/mods.py
+++ b/PyPoE/cli/exporter/wiki/parsers/mods.py
@@ -259,9 +259,10 @@ class ModParser(BaseParser):
 
             stats = []
             values = []
+            buffstats = mod["BuffTemplate"]["StatsKey"] if mod["BuffTemplate"] else []
             for i in MOD_STATS_RANGE:
                 k = mod["StatsKey%s" % i]
-                if k is None:
+                if k is None or k in buffstats:
                     continue
 
                 stat = k["Id"]


### PR DESCRIPTION
# Abstract

Remove unnecessary stats from modifiers, fixing https://github.com/Project-Path-of-Exile-Wiki/PyPoE/issues/126

# Action Taken

Modifiers that grant buffs contain their own stats as well as the stats granted by the buff in the mods.dat table. This change removes all stats granted by the buff from the modifier, so mods such as [Nearby Enemies' Chaos Resistance is 0](https://www.poewiki.net/wiki/Modifier:NearbyEnemyZeroChaosDamageResistanceUnique~~1) will not also say "Chaos Resistance is Zero".

# Caveats

This is a naive approach to this issue; there may be some other way that the game hides these stats, but it seems to work for all the cases that l am aware of.
