### PR TITLE
Handle GGPK chunk sizes larger than 2 GiB

### DIFF
--- a/PyPoE/poe/file/ggpk.py
+++ b/PyPoE/poe/file/ggpk.py
@@ -162,7 +162,7 @@ class BaseRecord(ReprMixin):
         ggpkfile : GGPKFile
             GGPKFile instance
         """
-        ggpkfile.write(struct.pack("<i", self.length))
+        ggpkfile.write(struct.pack("<I", self.length))
         ggpkfile.write(self.tag)
 
 
@@ -587,7 +587,7 @@ class GGPKFile(AbstractFileReadOnly, metaclass=InheritedDocStringsMeta):
     #
 
     def _read_record(self, records, ggpkfile, offset: int):
-        length = struct.unpack("<i", ggpkfile.read(4))[0]
+        length = struct.unpack("<I", ggpkfile.read(4))[0]
         tag = ggpkfile.read(4)
 
         """for recordcls in recordsc:


### PR DESCRIPTION
# Abstract

While most entries aren't overly large, `FREE` chunks for data holes can be surprisingly large and can cause the GGPK parser to never complete at it loops backwards.

# Action Taken

This PR reads the chunk size as unsigned to ensure that it can handle the full range of chunk sizes.

# Caveats

n/a

# FAO

n/a