### PR TITLE
Fix Silver flask export

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2983,12 +2983,21 @@ class ItemsParser(SkillParserShared):
 
         if flasks["BuffDefinitionsKey"]:
             stats = [s["Id"] for s in flasks["BuffDefinitionsKey"]["StatsKeys"]]
-            tr = self.tc["stat_descriptions.txt"].get_translation(
-                stats,
-                flasks["BuffStatValues"],
-                full_result=True,
-                lang=self._language,
-            )
+            if stats.len() > 0:
+                tr = self.tc["stat_descriptions.txt"].get_translation(
+                    stats,
+                    flasks["BuffStatValues"],
+                    full_result=True,
+                    lang=self._language,
+                )
+            else:
+                stats = [s["Id"] for s in flasks["BuffDefinitionsKey"]["Binary_StatsKeys"]]
+                tr = self.tc["stat_descriptions.txt"].get_translation(
+                    stats,
+                    flasks["BuffStatValues"],
+                    full_result=True,
+                    lang=self._language,
+                )
             infobox["buff_stat_text"] = "<br>".join(
                 [parser.make_inter_wiki_links(line) for line in tr.lines]
             )


### PR DESCRIPTION
# Abstract

Silver flask was always losing the "Onslaught" text when exported

# Action Taken

I pulled the text from the Buff flags instead of the Buff stats since Silver flask didn't have the latter

# Caveats

I wasn't able to test this locally yet (I blame trying to do this via Windows Store python) but I put it up for review until I can get on my main dev box.
