### PR TITLE
treat the dat schema as a prefix

### DIFF
--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -847,7 +847,7 @@ class DatReader(ReprMixin):
 
         # Unpacking the entire row in one go will help breaking down the
         # function calls significantly
-        row_unpacked = struct.unpack(self.cast_row, data_raw[:self.cast_size])
+        row_unpacked = struct.unpack(self.cast_row, data_raw[: self.cast_size])
         i = 0
         for spec, casts in self.cast_spec:
             if casts[0][0] in [3, 6]:

--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -847,7 +847,7 @@ class DatReader(ReprMixin):
 
         # Unpacking the entire row in one go will help breaking down the
         # function calls significantly
-        row_unpacked = struct.unpack(self.cast_row, data_raw)
+        row_unpacked = struct.unpack(self.cast_row, data_raw[:self.cast_size])
         i = 0
         for spec, casts in self.cast_spec:
             if casts[0][0] in [3, 6]:
@@ -896,7 +896,7 @@ class DatReader(ReprMixin):
         if self.specification is None:
             self.cast_size = self.table_record_length
 
-        if self.cast_size != self.table_record_length:
+        if self.cast_size > self.table_record_length:
             raise SpecificationError(
                 SpecificationError.ERRORS.RUNTIME_ROWSIZE_MISMATCH,
                 '"%(name)s": Specification row size %(spec_size)s vs real size %(cast_size)s'


### PR DESCRIPTION
# Abstract

https://github.com/Project-Path-of-Exile-Wiki/PyPoE/issues/79

# Action Taken

Relax the column length validation slightly so an extra column added to the end of a table doesn't cause an error

# Caveats

The usual caveats for loosening validation apply, though the risk in this case is probably quite low.
