### PR TITLE
fix harness the void and soul drinker class name

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -120,6 +120,9 @@ class PassiveSkillCommandHandler(ExporterHandler):
         )
 
 
+CLASS_PASSIVES = [f"AscendancySpecialEldritch{i}" for i in range(1, 6)] + ["AscendancyTrickster14"]
+
+
 class PassiveSkillParser(parser.BaseParser):
     _files = [
         "PassiveSkills.dat64",
@@ -189,15 +192,15 @@ class PassiveSkillParser(parser.BaseParser):
             {
                 "template": "ascendancy_class",
                 "format": lambda value: value["Name"],
-                "condition": lambda passive: "SpecialEldritch" not in passive["Id"],
             },
         ),
         (
+            # Overwrite ascendancy class with character class for forbidden-jewel-only passives
             "AscendancyKey",
             {
                 "template": "ascendancy_class",
                 "format": lambda value: value["CharactersKey"][0]["Name"],
-                "condition": lambda passive: "SpecialEldritch" in passive["Id"],
+                "condition": lambda passive: passive["Id"] in CLASS_PASSIVES,
             },
         ),
         (


### PR DESCRIPTION
# Abstract

Change how Forbidden jewel-only passives are idenitfied

# Action Taken

Passives that can only be obtained from Forbidden Flame/Flesh jewels are identified and linked to a character class rather than a random ascendancy within the class. This is done by checking the passive id. Rather than assuming that all passives with 'AscendancySpecialEldritch' in their id are forbidden passives, there is now a constant containing the list of ids.

# Caveats

Unleashed Potential is not included in the list, as there is only one ascendancy class for scion.