### PR TITLE
3.23 Update

### DIFF
--- a/PyPoE/cli/exporter/util.py
+++ b/PyPoE/cli/exporter/util.py
@@ -71,7 +71,7 @@ def get_content_path():
             with request.urlopen(
                 "https://raw.githubusercontent.com/poe-tool-dev/latest-patch-version/main/latest.txt"  # noqa
             ) as latest:
-                return f"http://patchcdn.pathofexile.com/{latest.read().decode('utf-8')}/"
+                return f"https://patch.poecdn.com/{latest.read().decode('utf-8')}/"
 
         return paths[0]
     else:

--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -851,12 +851,6 @@ class DelveParser(GenericLuaParser):
             },
         ),
         (
-            "CanRollEnchant",
-            {
-                "key": "can_enchant",
-            },
-        ),
-        (
             "CanImproveQuality",
             {
                 "key": "can_quality",

--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -1078,11 +1078,16 @@ class SkillParser(SkillParserShared):
         self._image_init(parsed_args=parsed_args)
         console("Found %s skills, parsing..." % len(skills))
         self.rr["GemEffects.dat64"].build_index("GrantedEffect")
+        self.rr["SkillGems.dat64"].build_index("GemEffects")
         r = ExporterResult()
         for skill in skills:
             if (
                 not parsed_args.allow_skill_gems
                 and skill in self.rr["GemEffects.dat64"].index["GrantedEffect"]
+                and any(
+                    effect in self.rr["SkillGems.dat64"].index["GemEffects"]
+                    for effect in self.rr["GemEffects.dat64"].index["GrantedEffect"][skill]
+                )
             ):
                 console(
                     f"Skipping skill gem skill \"{skill['Id']}\" at row {skill.rowid}",

--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -758,11 +758,9 @@ class SkillParserShared(parser.BaseParser):
             if row["GrantedEffectsKey"] == gra_eff:
                 qual_stats.append(row)
 
-        qual_stats.sort(key=lambda row: row["SetId"])
-
         for row in qual_stats:
-            prefix = "quality_type%s_" % (row["SetId"] + 1)
-            infobox[prefix + "weight"] = row["Weight"]
+            prefix = "quality_type1_"
+            infobox[prefix + "weight"] = 1
 
             # Quality stat data
             stat_ids = [r["Id"] for r in row["StatsKeys"]]
@@ -1079,12 +1077,12 @@ class SkillParser(SkillParserShared):
     def export(self, parsed_args, skills):
         self._image_init(parsed_args=parsed_args)
         console("Found %s skills, parsing..." % len(skills))
-        self.rr["SkillGems.dat64"].build_index("GrantedEffectsKey")
+        self.rr["GemEffects.dat64"].build_index("GrantedEffect")
         r = ExporterResult()
         for skill in skills:
             if (
                 not parsed_args.allow_skill_gems
-                and skill in self.rr["SkillGems.dat64"].index["GrantedEffectsKey"]
+                and skill in self.rr["GemEffects.dat64"].index["GrantedEffect"]
             ):
                 console(
                     f"Skipping skill gem skill \"{skill['Id']}\" at row {skill.rowid}",

--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -725,8 +725,12 @@ class MOD_DOMAIN(IntEnumOverride):
     SENTINEL = 30
     MEMORY_LINES = 31
     SANCTUM_RELIC = 32
-    MODS_DISALLOWED = 33  # Used in BaseItemTypes.dat, not Mods.dat.
-    CRUCIBLE = 34
+    CRUCIBLE_REMNANT = 33
+    TINCTURE = 34
+    AFFLICTION_CHARM = 35
+
+    # Items that can't have mods (may need to increase the number when new values are added)
+    MODS_DISALLOWED = 36
 
     # legacy names
     MASTER = CRAFTED

--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -377,7 +377,7 @@ class DatRecord(list):
 
     __slots__ = ["parent", "rowid"]
 
-    def __init__(self, parent, rowid):
+    def __init__(self, parent: "DatReader", rowid: int):
         """
         Parameters
         ----------
@@ -406,7 +406,7 @@ class DatRecord(list):
                     value = next(filter(lambda v: v is not None, value), None)
                 return value
             else:
-                raise KeyError(item)
+                raise KeyError(f"No column {item} found in {self.parent.file_name}")
         return list.__getitem__(self, item)
 
     def __repr__(self):

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -340,6 +340,15 @@ specification = Specification(
                 ),
             ),
         ),
+        "ActionTypes.dat": File(
+            fields=(
+                Field(
+                    name="Id",
+                    type="ref|string",
+                    unique=True,
+                ),
+            ),
+        ),
         "ActiveSettings.dat": File(
             fields=(
                 Field(
@@ -407,8 +416,9 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Unknown0",
-                    type="ref|string",
+                    name="ActionType",
+                    type="ref|out",
+                    key="ActionTypes.dat",
                 ),
                 Field(
                     name="Icon_DDSFile",
@@ -443,7 +453,7 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="Unknown0",
                     type="ref|string",
                 ),
                 Field(
@@ -487,7 +497,7 @@ specification = Specification(
                     key="Stats.dat",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="Unknown1",
                     type="int",
                 ),
                 Field(
@@ -7795,10 +7805,6 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="CanRollEnchant",
-                    type="bool",
-                ),
-                Field(
                     name="HasLuckyRolls",
                     type="bool",
                 ),
@@ -10812,6 +10818,60 @@ specification = Specification(
                 ),
             ),
         ),
+        "GemEffects.dat": File(
+            fields=(
+                Field(
+                    name="Id",
+                    type="ref|string",
+                    unique=True,
+                ),
+                Field(
+                    name="Name",
+                    type="ref|string",
+                    unique=True,
+                ),
+                Field(
+                    name="GrantedEffect",
+                    type="ref|out",
+                    key="GrantedEffects.dat",
+                ),
+                Field(
+                    name="GrantedEffectHardMode",
+                    type="ref|out",
+                    key="GrantedEffects.dat",
+                ),
+                Field(
+                    name="GrantedEffect2",
+                    type="ref|out",
+                    key="GrantedEffects.dat",
+                ),
+                Field(
+                    name="GrantedEffect2HardMode",
+                    type="ref|out",
+                    key="GrantedEffects.dat",
+                ),
+                Field(
+                    name="Description",
+                    type="ref|string",
+                    unique=True,
+                ),
+                Field(
+                    name="SupportSkillName",
+                    type="ref|string",
+                    unique=True,
+                ),
+                Field(
+                    name="GemTags",
+                    type="ref|list|ref|out",
+                    key="GemTags.dat",
+                ),
+                Field(
+                    name="Consumed_ModsKey",
+                    type="ref|out",
+                    key="Mods.dat",
+                ),
+            ),
+        ),
         "GemTags.dat": File(
             fields=(
                 Field(
@@ -11607,28 +11667,12 @@ specification = Specification(
                     key="GrantedEffects.dat",
                 ),
                 Field(
-                    name="SetId",
-                    type="int",
-                ),
-                Field(
                     name="StatsKeys",
                     type="ref|list|ref|out",
                     key="Stats.dat",
                 ),
                 Field(
                     name="StatsValuesPermille",
-                    type="ref|list|int",
-                ),
-                Field(
-                    name="Weight",
-                    type="int",
-                ),
-                Field(
-                    name="Data0",
-                    type="ref|list|int",
-                ),
-                Field(
-                    name="Data1",
                     type="ref|list|int",
                 ),
             ),
@@ -11718,6 +11762,19 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
+                    name="BaseResolvedValues",
+                    type="ref|list|int",
+                ),
+                Field(
+                    name="AdditionalStatsValues",
+                    type="ref|list|int",
+                ),
+                Field(
+                    name="GrantedEffects",
+                    type="ref|list|ref|out",
+                    key="GrantedEffects.dat",
+                ),
+                Field(
                     name="AdditionalFlags",
                     type="ref|list|ref|out",
                     key="Stats.dat",
@@ -11744,19 +11801,6 @@ specification = Specification(
                 Field(
                     name="FloatStatsValues",
                     type="ref|list|float",
-                ),
-                Field(
-                    name="BaseResolvedValues",
-                    type="ref|list|int",
-                ),
-                Field(
-                    name="AdditionalStatsValues",
-                    type="ref|list|int",
-                ),
-                Field(
-                    name="GrantedEffects",
-                    type="ref|list|ref|out",
-                    key="GrantedEffects.dat",
                 ),
             ),
         ),
@@ -18016,6 +18060,10 @@ specification = Specification(
                 ),
                 Field(
                     name="AncestorTier",
+                    type="int",
+                ),
+                Field(
+                    name="AzmeriTier",
                     type="int",
                 ),
             ),
@@ -27024,11 +27072,6 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="GrantedEffectsKey",
-                    type="ref|out",
-                    key="GrantedEffects.dat",
-                ),
-                Field(
                     name="StrengthRequirementPercent",
                     type="int",
                 ),
@@ -27041,11 +27084,6 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="GemTagsKeys",
-                    type="ref|list|ref|out",
-                    key="GemTags.dat",
-                ),
-                Field(
                     name="VaalVariant_BaseItemTypesKey",
                     type="ref|out",
                     key="BaseItemTypes.dat",
@@ -27055,27 +27093,9 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Description",
-                    type="ref|string",
-                ),
-                Field(
-                    name="Consumed_ModsKey",
-                    type="ref|out",
-                    key="Mods.dat",
-                ),
-                Field(
-                    name="GrantedEffectsKey2",
-                    type="ref|out",
-                    key="GrantedEffects.dat",
-                ),
-                Field(
                     name="MinionGlobalSkillLevelStat",
                     type="ref|out",
                     key="Stats.dat",
-                ),
-                Field(
-                    name="SupportSkillName",
-                    type="ref|string",
                 ),
                 Field(
                     name="IsSupport",
@@ -27112,15 +27132,6 @@ specification = Specification(
                     key="SkillGems.dat",
                 ),
                 Field(
-                    name="GrantedEffectHardMode",
-                    type="ref|out",
-                    key="GrantedEffects.dat",
-                ),
-                Field(
-                    name="Key0",
-                    type="ref|out",
-                ),
-                Field(
                     name="Unknown0",
                     type="int",
                 ),
@@ -27133,6 +27144,11 @@ specification = Specification(
                     name="MtxSlotTypes",
                     type="ref|list|ref|out",
                     key="MicrotransactionSkillGemEffectSlotTypes.dat",
+                ),
+                Field(
+                    name="GemEffects",
+                    type="ref|list|ref|out",
+                    key="GemEffects.dat",
                 ),
             ),
             virtual_fields=(

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -539,11 +539,11 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="ActNumber",
+                    name="Unknown1",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="ActNumber",
                     type="int",
                 ),
                 Field(
@@ -1119,9 +1119,9 @@ specification = Specification(
         "AlternateQualityTypes.dat": File(
             fields=(
                 Field(
-                    name="StatsKey",
+                    name="QualityModifier",
                     type="ref|out",
-                    key="Stats.dat",
+                    key="Mods.dat",
                 ),
                 Field(
                     name="Description",
@@ -1133,9 +1133,8 @@ specification = Specification(
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="ModsKey",
+                    name="Key0",
                     type="ref|out",
-                    key="Mods.dat",
                 ),
             ),
         ),
@@ -1552,15 +1551,17 @@ specification = Specification(
         "AncestralTrialTribeOpinions.dat": File(
             fields=(
                 Field(
-                    name="Key0",
+                    name="SourceTribe",
                     type="ref|out",
+                    key="AncestralTrialTribes.dat",
                 ),
                 Field(
-                    name="Key1",
+                    name="TargetTribe",
                     type="ref|out",
+                    key="AncestralTrialTribes.dat",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="Opinion",
                     type="int",
                 ),
             ),
@@ -1570,6 +1571,7 @@ specification = Specification(
                 Field(
                     name="Id",
                     type="ref|string",
+                    unique=True,
                 ),
                 Field(
                     name="Key0",
@@ -1586,6 +1588,7 @@ specification = Specification(
                 Field(
                     name="TribeName",
                     type="ref|string",
+                    unique=True,
                 ),
                 Field(
                     name="FavourTracker",
@@ -1731,12 +1734,14 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="Key0",
+                    name="ItemVisualIdentity",
                     type="ref|out",
+                    key="ItemVisualIdentity.dat",
                 ),
                 Field(
-                    name="Key1",
+                    name="ItemClass",
                     type="ref|out",
+                    key="ItemClasses.dat",
                 ),
                 Field(
                     name="Unknown0",
@@ -3216,23 +3221,24 @@ specification = Specification(
         "BattlePassRewards.dat": File(
             fields=(
                 Field(
-                    name="Key0",
+                    name="BattlePass",
                     type="ref|out",
+                    key="BattlePasses.dat",
+                ),
+                Field(
+                    name="RewardTier",
+                    type="int",
+                ),
+                Field(
+                    name="FreeReward",
+                    type="bool",
                 ),
                 Field(
                     name="Unknown0",
                     type="int",
                 ),
                 Field(
-                    name="Flag0",
-                    type="bool",
-                ),
-                Field(
                     name="Unknown1",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown2",
                     type="int",
                 ),
                 Field(
@@ -3240,20 +3246,45 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Data0",
-                    type="ref|list|byte",
+                    name="RewardedMTX",
+                    type="ref|list|ref|out",
+                    key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Unknown3",
+                    name="Unknown2",
                     type="int",
                 ),
                 Field(
-                    name="Unknown4",
+                    name="RewardDescription",
                     type="ref|string",
                 ),
                 Field(
-                    name="Unknown5",
+                    name="Unknown3",
                     type="ref|string",
+                ),
+                Field(
+                    name="Unknown4",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown5",
+                    type="int",
+                ),
+                Field(
+                    name="Flag0",
+                    type="bool",
+                ),
+                Field(
+                    name="RewardTitle",
+                    type="ref|string",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Flag1",
+                    type="bool",
                 ),
                 Field(
                     name="Unknown6",
@@ -3264,20 +3295,8 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Flag1",
-                    type="bool",
-                ),
-                Field(
                     name="Unknown8",
-                    type="ref|string",
-                ),
-                Field(
-                    name="Key1",
-                    type="ref|out",
-                ),
-                Field(
-                    name="Flag2",
-                    type="bool",
+                    type="int",
                 ),
                 Field(
                     name="Unknown9",
@@ -3300,16 +3319,8 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Unknown14",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown15",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown16",
-                    type="int",
+                    name="Flag2",
+                    type="bool",
                 ),
                 Field(
                     name="Flag3",
@@ -3317,10 +3328,6 @@ specification = Specification(
                 ),
                 Field(
                     name="Flag4",
-                    type="bool",
-                ),
-                Field(
-                    name="Flag5",
                     type="bool",
                 ),
             ),
@@ -3346,7 +3353,7 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="Unknown0",
+                    name="LeagueCategory",
                     type="int",
                 ),
                 Field(
@@ -3358,7 +3365,7 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="MapCompletionCount",
                     type="int",
                 ),
                 Field(
@@ -4431,32 +4438,32 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="BaseItemTypesKey",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="FirstSlotIndex",
                     type="int",
                 ),
                 Field(
-                    name="Unknown3",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="Unknown4",
+                    name="Height",
                     type="int",
                 ),
                 Field(
-                    name="Unknown5",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
@@ -4863,26 +4870,29 @@ specification = Specification(
         "Breachstones.dat": File(
             fields=(
                 Field(
-                    name="Key0",
+                    name="BaseType",
                     type="ref|out",
+                    key="BaseItemTypes.dat",
                     unique=True,
+                ),
+                Field(
+                    name="MapTierEquivalent",
+                    type="int",
                 ),
                 Field(
                     name="Unknown0",
                     type="int",
-                ),
-                Field(
-                    name="Unknown1",
-                    type="int",
                     unique=True,
                 ),
                 Field(
-                    name="Key1",
+                    name="UpgradesTo",
                     type="ref|out",
+                    key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Key2",
+                    name="UpgradeCurrency",
                     type="ref|out",
+                    key="BaseItemTypes.dat",
                 ),
             ),
         ),
@@ -7051,7 +7061,7 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="Stacks",
+                    name="StackSize",
                     type="int",
                 ),
                 Field(
@@ -7082,7 +7092,7 @@ specification = Specification(
                     key="AchievementItems.dat",
                 ),
                 Field(
-                    name="Flag0",
+                    name="Scroll",
                     type="bool",
                 ),
                 Field(
@@ -7151,7 +7161,7 @@ specification = Specification(
                     key="ShopTag.dat",
                 ),
                 Field(
-                    name="IsHardmode",
+                    name="ChangedForHardmode",
                     type="bool",
                 ),
                 Field(
@@ -7164,6 +7174,11 @@ specification = Specification(
                 ),
             ),
             virtual_fields=(
+                VirtualField(
+                    name="Stacks",
+                    fields=("StackSize",),
+                    alias=True,
+                ),
                 VirtualField(
                     name="ShopTagKey",
                     fields=("ShopTag",),
@@ -7178,36 +7193,36 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="BaseItemTypesKey",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="FirstSlotIndex",
                     type="int",
                 ),
                 Field(
-                    name="Unknown3",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="Unknown4",
+                    name="Height",
                     type="int",
                 ),
                 Field(
-                    name="Flag0",
+                    name="ShowIfEmpty",
                     type="bool",
                 ),
                 Field(
-                    name="Unknown5",
+                    name="SlotGroup",
                     type="int",
                 ),
             ),
@@ -7581,20 +7596,20 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="BaseItemType",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="X",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="Y",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="IntId",
+                    name="FirstSlotIndex",
                     type="int",
                     unique=True,
                 ),
@@ -7607,7 +7622,7 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
@@ -7636,7 +7651,7 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="IsEnabled",
+                    name="IsResonator",
                     type="bool",
                 ),
                 Field(
@@ -8283,20 +8298,20 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="BaseItemTypesKey",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="X",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="Y",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="IntId",
+                    name="FirstSlotIndex",
                     type="int",
                     unique=True,
                 ),
@@ -8309,11 +8324,11 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="StackSize",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
-                    name="HideIfNoneOwned",
+                    name="HideIfEmpty",
                     type="bool",
                 ),
                 Field(
@@ -8558,17 +8573,17 @@ specification = Specification(
         "DivinationCardStashTabLayout.dat": File(
             fields=(
                 Field(
-                    name="BaseItemTypesKey",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                     unique=True,
                 ),
                 Field(
-                    name="IsEnabled",
+                    name="IsInGame",
                     type="bool",
                 ),
                 Field(
-                    name="Flag0",
+                    name="IsEnabled",
                     type="bool",
                 ),
             ),
@@ -8616,15 +8631,15 @@ specification = Specification(
                     key="DroneTypes.dat",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="Charges",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="Duration",
                     type="int",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="EnemyLimit",
                     type="int",
                 ),
                 Field(
@@ -8633,7 +8648,7 @@ specification = Specification(
                     key="BuffVisuals.dat",
                 ),
                 Field(
-                    name="Unknown3",
+                    name="Empowerment",
                     type="int",
                 ),
                 Field(
@@ -8642,7 +8657,7 @@ specification = Specification(
                     key="AchievementItems.dat",
                 ),
                 Field(
-                    name="Flag0",
+                    name="CreatedViaPowerCore",
                     type="bool",
                 ),
             ),
@@ -9159,29 +9174,29 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="BaseItemTypesKey",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="X",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="Y",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="IntId",
+                    name="FirstSlotIndex",
                     type="int",
                     unique=True,
                 ),
                 Field(
-                    name="SlotWidth",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="SlotHeight",
+                    name="Height",
                     type="int",
                 ),
                 Field(
@@ -10105,16 +10120,16 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="BaseItemType",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="PosX",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="PosY",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
@@ -10438,12 +10453,13 @@ specification = Specification(
         "FlaskStashBaseTypeOrdering.dat": File(
             fields=(
                 Field(
-                    name="Key0",
+                    name="Flask",
                     type="ref|out",
+                    key="Flasks.dat",
                     unique=True,
                 ),
                 Field(
-                    name="Unknown0",
+                    name="Order",
                     type="int",
                     unique=True,
                 ),
@@ -10462,7 +10478,7 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Group",
+                    name="Type",
                     type="int",
                 ),
                 Field(
@@ -10573,23 +10589,23 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="PosX",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="PosY",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="Order",
+                    name="FirstSlotIndex",
                     type="int",
                 ),
                 Field(
-                    name="SizeX",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="SizeY",
+                    name="Height",
                     type="int",
                 ),
                 Field(
@@ -10601,11 +10617,11 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
-                    name="IsDisabled",
+                    name="HideIfEmpty",
                     type="bool",
                 ),
                 Field(
@@ -10613,7 +10629,7 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="FragmentItems",
+                    name="StoredItems",
                     type="ref|list|ref|out",
                     key="BaseItemTypes.dat",
                 ),
@@ -10622,11 +10638,11 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="Unknown0",
                     type="ref|string",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="Unknown1",
                     type="int",
                 ),
             ),
@@ -11481,20 +11497,21 @@ specification = Specification(
         "GiftWrapArtVariations.dat": File(
             fields=(
                 Field(
+                    name="Width",
+                    type="int",
+                ),
+                Field(
+                    name="Height",
+                    type="int",
+                ),
+                Field(
                     name="Unknown0",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown2",
-                    type="int",
-                ),
-                Field(
-                    name="Key0",
+                    name="Item",
                     type="ref|out",
+                    key="BaseItemTypes.dat",
                 ),
             ),
         ),
@@ -13765,7 +13782,7 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="BaseItemType",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
@@ -13778,7 +13795,7 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
@@ -13787,11 +13804,15 @@ specification = Specification(
                     key="HeistJobs.dat",
                 ),
                 Field(
-                    name="Columns",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="Rows",
+                    name="Height",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown0",
                     type="int",
                 ),
                 Field(
@@ -13804,10 +13825,6 @@ specification = Specification(
                 ),
                 Field(
                     name="Unknown3",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown4",
                     type="int",
                 ),
                 Field(
@@ -15018,7 +15035,7 @@ specification = Specification(
         "InfluenceExalts.dat": File(
             fields=(
                 Field(
-                    name="Id",
+                    name="Influence",
                     type="int",
                     unique=True,
                 ),
@@ -15359,15 +15376,15 @@ specification = Specification(
                     key="AchievementItems.dat",
                 ),
                 Field(
+                    name="UsedInMapDevice",
+                    type="bool",
+                ),
+                Field(
                     name="Flag2",
                     type="bool",
                 ),
                 Field(
                     name="Flag3",
-                    type="bool",
-                ),
-                Field(
-                    name="Flag4",
                     type="bool",
                 ),
             ),
@@ -18843,32 +18860,32 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="BaseItemTypesKey",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="XOffset",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="YOffset",
                     type="int",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="FirstSlotIndex",
                     type="int",
                 ),
                 Field(
-                    name="Unknown3",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="Unknown4",
+                    name="Height",
                     type="int",
                 ),
                 Field(
-                    name="Unknown5",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
@@ -24873,20 +24890,23 @@ specification = Specification(
                     key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Key0",
+                    name="TriggeredQuestFlag",
                     type="ref|out",
+                    key="QuestFlags.dat",
                 ),
                 Field(
-                    name="Key1",
+                    name="Key0",
                     type="ref|out",
+                    key="QuestFlags.dat",
                 ),
                 Field(
                     name="Unknown0",
                     type="int",
                 ),
                 Field(
-                    name="Key2",
+                    name="Key1",
                     type="ref|out",
+                    key="QuestFlags.dat",
                 ),
                 Field(
                     name="Data0",
@@ -24901,7 +24921,7 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Key3",
+                    name="Key2",
                     type="ref|out",
                 ),
                 Field(
@@ -24909,7 +24929,7 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Key4",
+                    name="Key3",
                     type="ref|out",
                 ),
                 Field(
@@ -24917,7 +24937,7 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Key5",
+                    name="Key4",
                     type="ref|out",
                 ),
             ),
@@ -26489,7 +26509,7 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Key0",
+                    name="StoredItem",
                     type="ref|out",
                     key="BaseItemTypes.dat",
                 ),
@@ -26503,39 +26523,39 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="TabIcon",
                     type="ref|string",
+                ),
+                Field(
+                    name="XOffset",
+                    type="int",
+                ),
+                Field(
+                    name="YOffset",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="int",
                 ),
                 Field(
                     name="Unknown1",
                     type="int",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="Width",
                     type="int",
                 ),
                 Field(
-                    name="Unknown3",
+                    name="Height",
                     type="int",
                 ),
                 Field(
-                    name="Unknown4",
+                    name="SlotSize",
                     type="int",
                 ),
                 Field(
-                    name="Unknown5",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown6",
-                    type="int",
-                ),
-                Field(
-                    name="Unknown7",
-                    type="int",
-                ),
-                Field(
-                    name="Key1",
+                    name="Key0",
                     type="ref|out",
                     key="ItemClasses.dat",
                 ),
@@ -27009,15 +27029,15 @@ specification = Specification(
                     key="GrantedEffects.dat",
                 ),
                 Field(
-                    name="Str",
+                    name="StrengthRequirementPercent",
                     type="int",
                 ),
                 Field(
-                    name="Dex",
+                    name="DexterityRequirementPercent",
                     type="int",
                 ),
                 Field(
-                    name="Int",
+                    name="IntelligenceRequirementPercent",
                     type="int",
                 ),
                 Field(
@@ -27119,6 +27139,21 @@ specification = Specification(
                 VirtualField(
                     name="ExperienceProgression",
                     fields=("ItemExperienceType",),
+                    alias=True,
+                ),
+                VirtualField(
+                    name="Str",
+                    fields=("StrengthRequirementPercent",),
+                    alias=True,
+                ),
+                VirtualField(
+                    name="Int",
+                    fields=("IntelligenceRequirementPercent",),
+                    alias=True,
+                ),
+                VirtualField(
+                    name="Dex",
+                    fields=("DexterityRequirementPercent",),
                     alias=True,
                 ),
             ),
@@ -27550,7 +27585,7 @@ specification = Specification(
                     unique=True,
                 ),
                 Field(
-                    name="IntId",
+                    name="StashId",
                     type="int",
                     unique=True,
                 ),
@@ -27559,15 +27594,15 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Width",
-                    type="int",
-                ),
-                Field(
-                    name="Height",
-                    type="int",
-                ),
-                Field(
                     name="Unknown0",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown1",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown2",
                     type="int",
                 ),
                 Field(
@@ -27739,11 +27774,11 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="IsCartographerBox",
+                    name="Flag0",
                     type="bool",
                 ),
                 Field(
-                    name="Flag0",
+                    name="Flag1",
                     type="bool",
                 ),
                 Field(
@@ -28746,9 +28781,19 @@ specification = Specification(
         "TieredMicrotransactions.dat": File(
             fields=(
                 Field(
+                    name="MTX",
+                    type="ref|out",
+                    key="BaseItemTypes.dat",
+                    unique=True,
+                ),
+                Field(
+                    name="TierThresholds",
+                    type="ref|list|int",
+                ),
+                Field(
                     name="Key0",
                     type="ref|out",
-                    unique=True,
+                    key="Stats.dat",
                 ),
                 Field(
                     name="Data0",
@@ -28757,29 +28802,23 @@ specification = Specification(
                 Field(
                     name="Key1",
                     type="ref|out",
+                    key="Stats.dat",
+                ),
+                Field(
+                    name="TierCount",
+                    type="int",
+                ),
+                Field(
+                    name="Keys0",
+                    type="ref|list|ref|out",
+                    key="Stats.dat",
                 ),
                 Field(
                     name="Data1",
                     type="ref|list|byte",
                 ),
                 Field(
-                    name="Key2",
-                    type="ref|out",
-                ),
-                Field(
-                    name="Unknown0",
-                    type="int",
-                ),
-                Field(
                     name="Data2",
-                    type="ref|list|byte",
-                ),
-                Field(
-                    name="Data3",
-                    type="ref|list|byte",
-                ),
-                Field(
-                    name="Data4",
                     type="ref|list|byte",
                 ),
                 Field(
@@ -28791,19 +28830,21 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Key3",
+                    name="Key2",
                     type="ref|out",
+                    key="Stats.dat",
                 ),
             ),
         ),
         "TieredMicrotransactionsVisuals.dat": File(
             fields=(
                 Field(
-                    name="Key0",
+                    name="MTX",
                     type="ref|out",
+                    key="BaseItemTypes.dat",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="Tier",
                     type="int",
                 ),
                 Field(
@@ -28817,7 +28858,7 @@ specification = Specification(
                     file_ext=".dds",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="Unknown0",
                     type="int",
                 ),
             ),
@@ -29697,11 +29738,11 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="TotalCount",
                     type="int",
                 ),
                 Field(
-                    name="Unknown1",
+                    name="Unknown0",
                     type="int",
                 ),
                 Field(

--- a/PyPoE/poe/file/specification/fields.py
+++ b/PyPoE/poe/file/specification/fields.py
@@ -660,3 +660,13 @@ class VirtualField(_Common, ReprMixin):
 
     def __getitem__(self, item):
         return getattr(self, item)
+
+
+class Alias(VirtualField):
+    def __init__(self, name: str, target: str):
+        super().__init__(name, (target,), alias=True)
+
+
+class Zip(VirtualField):
+    def __init__(self, name: str, fields: Tuple[str, str]):
+        super().__init__(name, fields, zip=True)

--- a/PyPoE/poe/file/specification/generation/virtual_fields.py
+++ b/PyPoE/poe/file/specification/generation/virtual_fields.py
@@ -1,43 +1,31 @@
 from collections import defaultdict
 
 from PyPoE.poe.constants import VERSION
-from PyPoE.poe.file.specification.fields import VirtualField
+from PyPoE.poe.file.specification.fields import Alias, VirtualField, Zip
 
 virtual_fields_mappings = {
     VERSION.STABLE: defaultdict(
         list[VirtualField],
         {
             "BlightCraftingItems": [
-                VirtualField(
-                    name="BaseItemTypesKey",
-                    fields=("Oil",),
-                    alias=True,
-                ),
+                Alias("BaseItemTypesKey", "Oil"),
             ],
             "BuffDefinitions": [
-                VirtualField(
-                    name="Binary_StatsKeys",
-                    fields=("BinaryStats",),
-                    alias=True,
-                ),
+                Alias("Binary_StatsKeys", "BinaryStats"),
             ],
             "CraftingBenchOptions": [
-                VirtualField(
+                Zip(
                     name="Cost",
                     fields=("Cost_BaseItemTypes", "Cost_Values"),
-                    zip=True,
                 ),
                 VirtualField(
                     name="AddModOrEnchantment",
                     fields=("AddMod", "AddEnchantment"),
                 ),
             ],
+            "CurrencyItems": [Alias("Stacks", "StackSize")],
             "DelveUpgrades": [
-                VirtualField(
-                    name="Stats",
-                    fields=("StatsKeys", "StatValues"),
-                    zip=True,
-                ),
+                Zip("Stats", ("StatsKeys", "StatValues")),
             ],
             "GrantedEffectsPerLevel": [
                 VirtualField(
@@ -67,83 +55,31 @@ virtual_fields_mappings = {
                         "Stat8Float",
                     ),
                 ),
-                VirtualField(
-                    name="Stats",
-                    fields=("StatsKeys", "StatValues"),
-                    zip=True,
-                ),
-                VirtualField(
-                    name="Costs",
-                    fields=("CostTypesKeys", "CostAmounts"),
-                    zip=True,
-                ),
+                Zip("Stats", ("StatsKeys", "StatValues")),
+                Zip("Costs", ("CostTypesKeys", "CostAmounts")),
             ],
             "HarvestCraftOptions": [
-                VirtualField(
-                    name="HarvestCraftTiersKey",
-                    fields=("Tier",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="LifeforceCostType",
-                    fields=("LifeforceType",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="SacredBlossomCost",
-                    fields=("SacredCost",),
-                    alias=True,
-                ),
+                Alias("HarvestCraftTiersKey", "Tier"),
+                Alias("LifeforceCostType", "LifeforceType"),
+                Alias("SacredBlossomCost", "SacredCost"),
             ],
             "HeistAreas": [
-                VirtualField(
-                    name="ClientStringsKey",
-                    fields=("Reward",),
-                    alias=True,
-                ),
+                Alias("ClientStringsKey", "Reward"),
             ],
             "IndexableSkillGems": [
-                VirtualField(
-                    name="Name",
-                    fields=("Name1",),
-                    alias=True,
-                ),
+                Alias("Name", "Name1"),
             ],
             "MapPurchaseCosts": [
-                VirtualField(
-                    name="NormalPurchase",
-                    fields=("NormalPurchase_BaseItemTypesKeys", "NormalPurchase_Costs"),
-                    zip=True,
-                ),
-                VirtualField(
-                    name="MagicPurchase",
-                    fields=("MagicPurchase_BaseItemTypesKeys", "MagicPurchase_Costs"),
-                    zip=True,
-                ),
-                VirtualField(
-                    name="RarePurchase",
-                    fields=("RarePurchase_BaseItemTypesKeys", "RarePurchase_Costs"),
-                    zip=True,
-                ),
-                VirtualField(
-                    name="UniquePurchase",
-                    fields=("UniquePurchase_BaseItemTypesKeys", "UniquePurchase_Costs"),
-                    zip=True,
-                ),
+                Zip("NormalPurchase", ("NormalPurchase_BaseItemTypesKeys", "NormalPurchase_Costs")),
+                Zip("MagicPurchase", ("MagicPurchase_BaseItemTypesKeys", "MagicPurchase_Costs")),
+                Zip("RarePurchase", ("RarePurchase_BaseItemTypesKeys", "RarePurchase_Costs")),
+                Zip("UniquePurchase", ("UniquePurchase_BaseItemTypesKeys", "UniquePurchase_Costs")),
             ],
             "MapSeriesTiers": [
-                VirtualField(
-                    name="AncestralTier",
-                    fields=("AncestorTier",),
-                    alias=True,
-                ),
+                Alias("AncestralTier", "AncestorTier"),
             ],
             "Mods": [
-                VirtualField(
-                    name="SpawnWeight",
-                    fields=("SpawnWeight_TagsKeys", "SpawnWeight_Values"),
-                    zip=True,
-                ),
+                Zip("SpawnWeight", ("SpawnWeight_TagsKeys", "SpawnWeight_Values")),
                 VirtualField(
                     name="Stat1",
                     fields=("StatsKey1", "Stat1Min", "Stat1Max"),
@@ -183,11 +119,7 @@ virtual_fields_mappings = {
                     name="Stats",
                     fields=("Stat1", "Stat2", "Stat3", "Stat4", "Stat5", "Stat6"),
                 ),
-                VirtualField(
-                    name="GenerationWeight",
-                    fields=("GenerationWeight_TagsKeys", "GenerationWeight_Values"),
-                    zip=True,
-                ),
+                Zip("GenerationWeight", ("GenerationWeight_TagsKeys", "GenerationWeight_Values")),
             ],
             "MonsterMapBossDifficulty": [
                 VirtualField(
@@ -238,91 +170,42 @@ virtual_fields_mappings = {
                 ),
             ],
             "PantheonSouls": [
-                VirtualField(
-                    name="BaseItemTypesKey",
-                    fields=("CapturedVessel",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="MonsterVarietiesKey",
-                    fields=("CapturedMonster",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="PantheonPanelLayoutKey",
-                    fields=("PanelLayout",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="BossDescription",
-                    fields=("CapturedMonsterDescription",),
-                    alias=True,
-                ),
+                Alias("BaseItemTypesKey", "CapturedVessel"),
+                Alias("MonsterVarietiesKey", "CapturedMonster"),
+                Alias("PantheonPanelLayoutKey", "PanelLayout"),
+                Alias("BossDescription", "CapturedMonsterDescription"),
             ],
             "PassiveSkills": [
                 VirtualField(
                     name="StatValues",
                     fields=("Stat1Value", "Stat2Value", "Stat3Value", "Stat4Value", "Stat5Value"),
                 ),
-                VirtualField(
-                    name="StatsZip",
-                    fields=("Stats", "StatValues"),
-                    zip=True,
-                ),
-                VirtualField(
-                    name="ReminderTextKeys",
-                    fields=("ReminderStrings",),
-                    alias=True,
-                ),
+                Zip("StatsZip", ("Stats", "StatValues")),
+                Alias("ReminderTextKeys", "ReminderStrings"),
             ],
             "PassiveSkillMasteryEffects": [
                 VirtualField(
                     name="StatValues",
                     fields=("Stat1Value", "Stat2Value", "Stat3Value"),
                 ),
-                VirtualField(
-                    name="StatsZip",
-                    fields=("Stats", "StatValues"),
-                    zip=True,
-                ),
+                Zip("StatsZip", ("Stats", "StatValues")),
             ],
             "PassiveSkillOverrides": [
-                VirtualField(
-                    name="PassiveSkillOverrideTypesKey",
-                    fields=("Type",),
-                    alias=True,
-                ),
+                Alias("PassiveSkillOverrideTypesKey", "Type"),
             ],
             "PassiveSkillTattoos": [
-                VirtualField(
-                    name="BaseItemTypesKey",
-                    fields=("Tattoo",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="PassiveSkillOverrideTypesKey",
-                    fields=("OverrideType",),
-                    alias=True,
-                ),
+                Alias("BaseItemTypesKey", "Tattoo"),
+                Alias("PassiveSkillOverrideTypesKey", "OverrideType"),
             ],
             "WorldAreas": [
-                VirtualField(
-                    name="AreaType_TagsKeys",
-                    fields=("AreaTypeTags",),
-                    alias=True,
-                ),
-                VirtualField(
-                    name="VaalArea_WorldAreasKeys",
-                    fields=("VaalArea",),
-                    alias=True,
-                ),
+                Alias("AreaType_TagsKeys", "AreaTypeTags"),
+                Alias("VaalArea_WorldAreasKeys", "VaalArea"),
             ],
             "SkillGems": [
-                VirtualField(
-                    name="ExperienceProgression",
-                    fields=("ItemExperienceType",),
-                    alias=True,
-                ),
+                Alias("ExperienceProgression", "ItemExperienceType"),
+                Alias("Str", "StrengthRequirementPercent"),
+                Alias("Int", "IntelligenceRequirementPercent"),
+                Alias("Dex", "DexterityRequirementPercent"),
             ],
         },
     )

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -2592,6 +2592,12 @@ TQNumberFormat(
     divisor=10,
 )
 
+TQNumberFormat(
+    id="invert_chance",
+    multiplier=-1,
+    addend=100,
+)
+
 TranslationQuantifier(
     id="canonical_line",
     type=TranslationQuantifier.QuantifierTypes.STRING,

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -121,9 +121,7 @@ from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
 from enum import IntEnum
 from string import ascii_letters
-from typing import Any, Callable, Dict
-from typing import Iterable as t_Iterable
-from typing import List, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Tuple, TypeVar, Union, overload
 
 # self
 from PyPoE import DATA_DIR
@@ -181,7 +179,7 @@ regex_tokens = re.compile(
 _custom_translation_file = None
 _hardcoded_translation_file = None
 
-StatValue = Union[int, Tuple[int, int]]
+StatValue = TypeVar("StatValue", int, Tuple)
 """Numeric value to interpolate into a stat string. If a tuple is supplied,
  a range will be displayed instead"""
 
@@ -616,9 +614,10 @@ class TranslationString(TranslationReprMixin):
         values: Union[List[int], List[Tuple[int, int]]],
         is_range: List[bool],
         use_placeholder: Union[bool, Callable[[int], Any]] = False,
-        only_values: bool = False,
         custom_formatter: Callable = None,
-    ) -> Tuple[Union[str, List[int]], List[int], List[int], Dict[str, str]]:
+    ) -> Tuple[
+        Union[str, List[int]], List[int], List[int], Dict[str, str], List[str | Tuple[str, str]]
+    ]:
         """
         Formats the string for the given values.
 
@@ -643,13 +642,11 @@ class TranslationString(TranslationReprMixin):
             If a callable is specified, it will call the function with
             the index as first parameter. The callable should return a
             string to use as placeholder.
-        only_values
-            Only return the values and not
 
 
         Returns
         -------
-            Returns 4 values.
+            Returns 5 values.
 
             The first return value is the formatted string. If only placeholder
             is specified, instead of the string a list of parsed values is
@@ -659,11 +656,14 @@ class TranslationString(TranslationReprMixin):
 
             The third return value is a list of used values.
 
-            The forth return value is a dictionary of extra strings
+            The fourth return value is a dictionary of extra strings
+
+            The fifth return value is a list of formatted stat values
         """
         values, extra_strings, formats = self.quantifier.handle(values, is_range)
 
         string = []
+        formatted_values = [None for v in values]
         used = set()
         for i, tagid in enumerate(self.tags):
             try:
@@ -675,24 +675,29 @@ class TranslationString(TranslationReprMixin):
                 )
                 raise
 
-            if not only_values:
-                string.append(self.strings[i])
-                # For adding the plus sign to the $+d and $+d%% formats
-                if "+" in self.tags_types[i] and (
-                    is_range[tagid] and value[1] > 0 or not is_range[tagid] and value > 0
-                ):
-                    string.append("+")
+            string.append(self.strings[i])
+            # For adding the plus sign to the $+d and $+d%% formats
+            if "+" in self.tags_types[i] and (
+                is_range[tagid] and value[1] > 0 or not is_range[tagid] and value > 0
+            ):
+                string.append("+")
 
-                if not use_placeholder:
-                    if custom_formatter:
-                        value = custom_formatter(value)
+            if not use_placeholder:
+                if custom_formatter:
+                    value = custom_formatter(value)
+                    formatted_values[tagid] = (value, value)
+                else:
+                    if is_range[tagid]:
+                        formatted_values[tagid] = tuple(map(formats[tagid].format, value))
+                        value = formats[tagid].range_format(value)
                     else:
-                        value = formats[tagid](value)
+                        value = formats[tagid].format(value)
+                        formatted_values[tagid] = (value, value)
 
-                elif use_placeholder is True:
-                    value = ascii_letters[23 + i]
-                elif callable(use_placeholder):
-                    value = use_placeholder(i)
+            elif use_placeholder is True:
+                value = ascii_letters[23 + i]
+            elif callable(use_placeholder):
+                value = use_placeholder(i)
             string.append(value)
             used.add(tagid)
 
@@ -702,12 +707,9 @@ class TranslationString(TranslationReprMixin):
                 continue
             unused.append(val)
 
-        if only_values:
-            string = values
-        else:
-            string = "".join(string + [self.strings[-1]])
+        string = "".join(string + [self.strings[-1]])
 
-        return string, unused, values, extra_strings
+        return string, unused, values, extra_strings, formatted_values
 
     def match_range(self, values: List[Union[int, float]]) -> int:
         """
@@ -1053,7 +1055,7 @@ class TranslationQuantifierHandler(TranslationReprMixin):
 
     def handle(
         self, values: Union[List[int], List[Tuple[int, int]]], is_range: List[bool]
-    ) -> Tuple[List[Any], Dict[str, str], List[Callable]]:
+    ) -> Tuple[List[Any], Dict[str, str], List["TranslationQuantifier"]]:
         """
         Handle the given values based on the registered quantifiers.
 
@@ -1076,7 +1078,7 @@ class TranslationQuantifierHandler(TranslationReprMixin):
             The format strings for each value
         """
         values = list(values)
-        formats = [range_format if r else str for r in is_range]
+        formats = [noop_quantifier for r in is_range]
         for handler_name in self.index_handlers:
             f = self._get_handler_func(handler_name)
             if f is None:
@@ -1085,10 +1087,10 @@ class TranslationQuantifierHandler(TranslationReprMixin):
                 index -= 1
                 if is_range[index]:
                     values[index] = (f.handler(values[index][0]), f.handler(values[index][1]))
-                    formats[index] = f.range_format
+                    formats[index] = f
                 else:
                     values[index] = f.handler(values[index])
-                    formats[index] = f.format
+                    formats[index] = f
 
         for i, value in enumerate(values):
             if is_range[i]:
@@ -1135,13 +1137,6 @@ class TranslationQuantifierHandler(TranslationReprMixin):
             values[index] = int(values[index])
 
         return values
-
-
-def range_format(value: tuple):
-    if value[1] < 0:
-        return f"-({-value[0]}-{-value[1]})"
-    else:
-        return f"({value[0]}-{value[1]})"
 
 
 class TranslationQuantifier(TranslationReprMixin):
@@ -1216,6 +1211,9 @@ class TranslationQuantifier(TranslationReprMixin):
         else:
             v0, v1 = [self.format(v) for v in value]
             return f"({v0}-{v1})"
+
+
+noop_quantifier = TranslationQuantifier(id="tq_noop")
 
 
 class TQReminderString(TranslationQuantifier):
@@ -1489,7 +1487,7 @@ class TranslationFile(AbstractFileReadOnly):
 
     def __init__(
         self,
-        file_path: Union[t_Iterable[str], str, None] = None,
+        file_path: Union[Iterable[str], str, None] = None,
         base_dir: Union[str, None] = None,
         parent: Union["TranslationFileCache", None] = None,
     ):
@@ -1775,6 +1773,38 @@ class TranslationFile(AbstractFileReadOnly):
 
         # self.translations_hash.update(other.translations_hash)
 
+    @overload
+    def get_translation(
+        self,
+        tags: List,
+        values: Union[Dict, List],
+        full_result: Literal[True],
+        lang: str | None = "English",
+        use_placeholder: Union[bool, Callable, None] = False,
+    ) -> TranslationResult:
+        ...
+
+    @overload
+    def get_translation(
+        self,
+        tags: List[str],
+        values: Union[Dict[str, StatValue], List[StatValue]],
+        only_values: Literal[True],
+        lang: str | None = "English",
+        use_placeholder: Union[bool, Callable, None] = False,
+    ) -> Dict[str, Tuple[str, str]]:
+        ...
+
+    @overload
+    def get_translation(
+        self,
+        tags: List[str],
+        values: Union[Dict, List],
+        lang: str | None = "English",
+        use_placeholder: Union[bool, Callable, None] = False,
+    ) -> List[str]:
+        ...
+
     def get_translation(
         self,
         tags: List[str],
@@ -1783,7 +1813,7 @@ class TranslationFile(AbstractFileReadOnly):
         full_result: bool = False,
         use_placeholder: Union[bool, Callable] = False,
         only_values: bool = False,
-    ) -> Union[List[int], List[str], TranslationResult]:
+    ) -> Union[Dict[str, StatValue], List[str], TranslationResult]:
         """
         Attempts to retrieve a translation from the loaded translation file for
         the specified language with the given tags and values.
@@ -1890,15 +1920,21 @@ class TranslationFile(AbstractFileReadOnly):
         extra_strings = []
         string_instances = []
         tf_indices: List[int] = []
+        formatted_values = {}
         for i, tr in enumerate(trans_found):
             tl = tr.get_language(lang)
             ts, short_values, is_range = tl.get_string(trans_found_values[i])
             if ts:
                 string_instances.append(ts)
-                result = ts.format_string(short_values, is_range, use_placeholder, only_values)
+                result = ts.format_string(short_values, is_range, use_placeholder)
                 trans_lines.append(result[0])
                 trans_found_lines.append(result[0])
                 values_parsed.append(result[2])
+                if only_values:
+                    for stat, val in zip(tr.ids, result[4]):
+                        if val:
+                            formatted_values[stat] = val
+
                 if full_result:
                     unused.append(result[1])
                     extra_strings.append(result[3])
@@ -1926,7 +1962,7 @@ class TranslationFile(AbstractFileReadOnly):
                 tf_indices=tf_indices,
             )
         if only_values:
-            return values_parsed
+            return formatted_values
         else:
             return trans_lines
 

--- a/PyPoE/poe/sim/mods.py
+++ b/PyPoE/poe/sim/mods.py
@@ -83,6 +83,7 @@ _translation_map = {
     MOD_DOMAIN.PRIMORDIAL_ALTAR: "primordial_altar_stat_descriptions.txt",
     MOD_DOMAIN.SENTINEL: "sentinel_stat_descriptions.txt",
     MOD_DOMAIN.TEMPLAR_RELIC: "sanctum_relic_stat_descriptions.txt",
+    MOD_DOMAIN.TINCTURE: "tincture_stat_descriptions.txt",
 }
 
 # =============================================================================


### PR DESCRIPTION
# Abstract

Update with schema changes from 3.23

# Action Taken

This required a minor refactor of the items exporter - it can now export multiple items per entry in BaseItemTypes. Transfigured gems are exported as separate items.

# Caveats

Though the data structure has changed, the code wasn't significantly updated, so there is an unnecessary loop when exporting quality types. It would be nice to refactor this. Some day.
