### PR TITLE
fix metadata_id conflict

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2644,6 +2644,7 @@ class ItemsParser(SkillParserShared):
             return False
         if name:
             infobox["name"] = name
+            infobox["base_metadata_id"] = infobox.pop("metadata_id")
 
         # SkillGems.dat
         for attr_short, attr_long in self._attribute_map.items():


### PR DESCRIPTION
# Abstract

Trans gems have the same base item as the original, which causes a uniqueness error

# Action Taken

Changed the key to 'base_metadata_id' for alternate versions

# Caveats

The pages now have no 'metadata_id' key, which doesn't appear to be an issue, but if necessary a fake metadata id can be generated from the GemEffects id.