### PR TITLE
exclude pypoe edits from manual-revert check

### DIFF
--- a/PyPoE/cli/exporter/wiki/handler.py
+++ b/PyPoE/cli/exporter/wiki/handler.py
@@ -230,7 +230,9 @@ class WikiHandler:
                 console("Found text marked as Do Not Translate. Skipping.")
                 return
             revisions = page.exists and [
-                r["*"].splitlines() for r in page.revisions(limit=2, prop="content")
+                r["content"].splitlines()
+                for r in page.revisions(limit=2, prop="content|comment")
+                if not r["comment"].startswith("PyPoE/ExporterBot/")
             ]
             if revisions and new_lines in revisions:
                 console(


### PR DESCRIPTION
# Abstract

Allow the exporter to manually revert edits previously made by itself

# Action Taken

When updating a page, the exporter compares the proposed update to the previous revision, and if it would be a manual revert, does not perform the update. This helps detect cases where the bot has exported bad data that was fixed by a user.

This change checks the comment of the previous revision first and skips the check if it begins with `PyPoE/ExporterBot/`, to allow the bot to undo its own changes, e.g. when previously removed information gets added back into the data files.
