### PR TITLE
add relations between skills

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2716,8 +2716,16 @@ class ItemsParser(SkillParserShared):
         name = gem_type["Name"]
         if "[DNT]" in name:
             return False
-        if skill_gem["IsVaalVariant"] and gem_type["ItemColor"] != 3:
-            return False
+        if skill_gem["IsVaalVariant"]:
+            infobox["is_vaal_skill_gem"] = "true"
+            if gem_type["ItemColor"] != 3:
+                return False
+        if skill_gem["VaalVariant_BaseItemTypesKey"]:
+            infobox["vaal_variant_id"] = skill_gem["VaalVariant_BaseItemTypesKey"]["Id"]
+        if skill_gem["RegularVariant"]:
+            infobox["is_awakened_support_gem"] = "true"
+        if skill_gem["AwakenedVariant"]:
+            infobox["awakened_variant_id"] = skill_gem["AwakenedVariant"]["BaseItemTypesKey"]["Id"]
         if name:
             infobox["name"] = name
             infobox["base_item_id"] = infobox.pop("metadata_id")


### PR DESCRIPTION
# Abstract

Adds relations between skills, so the wiki can link base, transfigured, vaal, and awakened gems

# Action Taken

Adds `is_vaal_skill_gem`, `vaal_variant_id`, `is_awakened_support_gem`, and `awakened_variant_id` fields to gem items.
