### PR TITLE
Map fragments

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -3187,17 +3187,6 @@ class ItemsParser(SkillParserShared):
     )
 
     def _currency_extra(self, infobox, base_item_type, currency):
-        # Add the "shift click to unstack" stuff to currency-ish items
-        if currency["Stacks"] > 1 and infobox["class_id"] not in ("Microtransaction",):
-            if "help_text" in infobox:
-                infobox["help_text"] += "<br>"
-            else:
-                infobox["help_text"] = ""
-
-            infobox["help_text"] += self.rr["ClientStrings.dat64"].index["Id"][
-                "ItemDisplayStackDescription"
-            ]["Text"]
-
         if infobox.get("description"):
             infobox["description"] = parser.parse_and_handle_description_tags(
                 rr=self.rr,

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -4105,7 +4105,7 @@ class ItemsParser(SkillParserShared):
         # 'LabyrinthMapItem': (),
         # Misc
         "Map": (_type_map,),
-        "MapFragment": (_type_map_fragment_mods,),
+        "MapFragment": (_type_currency, _type_map_fragment_mods,),
         "QuestItem": (_skip_quest_contracts,),
         "AtlasRegionUpgradeItem": (),
         "MetamorphosisDNA": (),

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2576,6 +2576,10 @@ class ItemsParser(SkillParserShared):
         "Metadata/Items/Currency/SanctumCurrencyWindDancer",
         "Metadata/Items/Currency/SanctumCurrencyZealotsOath",
         # =================================================================
+        # Divination cards
+        # =================================================================
+        "Metadata/Items/DivinationCards/DivinationCardHisJudgement",
+        # =================================================================
         # Corpse items
         # =================================================================
         "Metadata/Items/ItemisedCorpses/FlameblasterLow",

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -3550,10 +3550,10 @@ class ItemsParser(SkillParserShared):
     def _map_fragment_extra(self, infobox, base_item_type, map_fragment_mods):
         if map_fragment_mods["ModsKeys"]:
             i = 1
-            while infobox.get("implicit%s" % i) is not None:
+            while infobox.get("map_fragment_bonus%s" % i) is not None:
                 i += 1
             for mod in map_fragment_mods["ModsKeys"]:
-                infobox["implicit%s" % i] = mod["Id"]
+                infobox["map_fragment_bonus%s" % i] = mod["Id"]
                 i += 1
 
     _type_map_fragment_mods = _type_factory(


### PR DESCRIPTION
# Abstract

Adds missing fields for map fragments.

# Action Taken

- Added unreleased divination card "His Judgement" to skip list.
- Export missing fields used by some map fragments: Stack size, stash tab stack size, and description. This also ensures that the full help text gets exported.
- Removed "Shift click to unstack" from currency item help text. In game, this text is only shown on stacks of currency items. We don't need it for the abstract item infobox.

# Caveats

The modifiers granted by map fragments used in the map device are currently exported as implicit modifiers. This is technically incorrect. In game, these modifiers are not displayed as if they are implicit modifiers either. Need to implement new fields for these before merging this PR.