### PR TITLE
Breachstones

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -3229,6 +3229,7 @@ class ItemsParser(SkillParserShared):
         ),
         row_index=True,
         function=_currency_extra,
+        fail_condition=True,
     )
 
     _COSMETIC_NAME_MAP = {

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -4107,6 +4107,7 @@ class ItemsParser(SkillParserShared):
         "HeistBlueprint": (),
         "Trinket": (),
         "HeistObjective": (),
+        "Breachstone": (_type_currency,),
         "ItemisedCorpse": (_type_corpse,),
     }
 


### PR DESCRIPTION
# Abstract

Adds missing fields for breachstones.

# Action Taken

- Export missing fields used by breachstones: Stack size, stash tab stack size, and description. This also ensures that the full help text gets exported.
- Allow the currency type parser to fail without skipping the entire item. This is necessary because some map fragments do not have corresponding entries in CurrencyItems.dat.