### PR TITLE
Bestiary recipes

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -489,6 +489,12 @@ class BestiaryParser(GenericLuaParser):
                 "key": "notes",
             },
         ),
+        (
+            "GameMode",
+            {
+                "key": "game_mode",
+            },
+        ),
     )
 
     _COPY_KEYS_BESTIARY_COMPONENTS = (

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -3925,8 +3925,9 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Unknown2",
+                    name="GameMode",
                     type="int",
+                    description="1: Normal, 2: Ruthless",
                 ),
                 Field(
                     name="FlaskMod",


### PR DESCRIPTION
Updated the lua exporter to include a field that specifies whether a Bestiary recipe is available in the normal game or in Ruthless mode.