### PR TITLE
compose map icons like the game

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -84,6 +84,7 @@ def gemshade_constants_from_hex(hex_text: str):
     buf = codecs.decode(hex_text.replace(" ", ""), "hex")
     return GemShadeConstants(*struct.unpack("<ffff", buf))
 
+
 def _srgb_to_linear(img):
     return np.piecewise(
         img,
@@ -91,12 +92,14 @@ def _srgb_to_linear(img):
         [lambda v: v / 12.92, lambda v: ((v + 0.055) / 1.055) ** 2.4],
     )
 
+
 def _linear_to_srgb(img):
     return np.piecewise(
         img,
         [img < 0.0031308, img >= 0.0031308],
         [lambda v: v * 12.92, lambda v: 1.055 * v ** (1.0 / 2.4) - 0.055],
     )
+
 
 def _apply_column_map(infobox, column_map: tuple[tuple[str, dict], ...], list_object):
     for k, data in column_map:
@@ -4105,7 +4108,7 @@ class ItemsParser(SkillParserShared):
         tex_colour = np.dstack((_srgb_to_linear(samples[:, :, :3]), samples[:, :, 3]))
         final = color * tex_colour
         final[:, :, :3] = _linear_to_srgb(final[:, :, :3])
-        return Image.fromarray(np.uint8(final * 255.), 'RGBA')
+        return Image.fromarray(np.uint8(final * 255.0), "RGBA")
 
     def export_map(self, parsed_args):
         r = ExporterResult()

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -18523,6 +18523,12 @@ specification = Specification(
                     file_path=True,
                     file_ext=".dds",
                 ),
+                Field(
+                    name="Purple_DDSFile",
+                    type="ref|string",
+                    file_path=True,
+                    file_ext=".dds",
+                ),
             ),
         ),
         "MapSeriesTiers.dat": File(


### PR DESCRIPTION
# Abstract

Implemented map item tinting and composition like the game does with accurate coefficients.

# Action Taken

With the introduction of five new purple T17 maps in 3.24 the old approximation of how maps were composed from a base plate and a colorized sigil was insufficient.

This change implements the relevant parts of the game UI shader for tinting UI elements like the map items, ignoring parts that are not used for these assets like saturation (always 1.0) and colour scaling (also always 1.0). For reference, see `PShad` in `Draw2D.hlsl`.

The colour tint for the four different tier groups is obtained from the game renderer for maximum correctness.

This also updates the defunct `atlas_icons` export to tint the sigils in the same way.

# Caveats

The generated table spec has new fields from a local copy of a pending PR to dat-schema to add a new `Purple_DDSFile` column to `MapSeries`.

# FAO

n/a