### PR TITLE
add pack descriptions to allflame embers

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -96,6 +96,16 @@ def _apply_column_map(infobox, column_map: tuple[tuple[str, dict], ...], list_ob
         infobox[data["template"]] = value
 
 
+def _markup_to_wiki(markup: str):
+    return "<br>".join(
+        re.sub(
+            r"<([^>]+)>{([^}]+)}",
+            lambda match: "{{c|%s|%s}}" % (match.group(1), match.group(2)),
+            markup,
+        ).splitlines()
+    )
+
+
 def _type_factory(
     data_file: str,
     data_mapping: tuple[tuple[str, dict], ...],
@@ -3239,7 +3249,28 @@ class ItemsParser(SkillParserShared):
                 "Description",
                 {
                     "template": "description",
-                    "format": lambda v: "<br>".join(str(v).splitlines()),
+                    "format": lambda v: "<br>".join(v.splitlines()),
+                },
+            ),
+            (
+                "Pack",
+                {
+                    "template": "pack_description",
+                    "format": lambda v: _markup_to_wiki(v["Description"]),
+                },
+            ),
+            (
+                "Pack",
+                {
+                    "template": "pack_leader_name",
+                    "format": lambda v: _markup_to_wiki(v["PackLeader1"]),
+                },
+            ),
+            (
+                "Pack",
+                {
+                    "template": "pack_leader_description",
+                    "format": lambda v: _markup_to_wiki(v["PackLeader2"]),
                 },
             ),
         ),

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -33,6 +33,7 @@ Kishara's Star (item)
 # =============================================================================
 
 import codecs
+import math
 import os
 
 # Python
@@ -94,16 +95,6 @@ def _apply_column_map(infobox, column_map: tuple[tuple[str, dict], ...], list_ob
         if data.get("format"):
             value = data["format"](value)
         infobox[data["template"]] = value
-
-
-def _markup_to_wiki(markup: str):
-    return "<br>".join(
-        re.sub(
-            r"<([^>]+)>{([^}]+)}",
-            lambda match: "{{c|%s|%s}}" % (match.group(1), match.group(2)),
-            markup,
-        ).splitlines()
-    )
 
 
 def _type_factory(
@@ -1981,6 +1972,41 @@ class ItemsParser(SkillParserShared):
             return False
         return True
 
+    def _allflame_ember(self, infobox: OrderedDict, base_item_type):
+        if "Item" not in self.rr["ItemisedNecropolisPacks.dat64"].index:
+            self.rr["ItemisedNecropolisPacks.dat64"].build_index("Item")
+        if "NecropolisPack" not in self.rr["MonsterPacks.dat64"].index:
+            self.rr["MonsterPacks.dat64"].build_index("NecropolisPack")
+        data = self.rr["ItemisedNecropolisPacks.dat64"].index["Item"][base_item_type.rowid]
+        monster_packs = self.rr["MonsterPacks.dat64"].index["NecropolisPack"][data["Pack"]]
+        if not data:
+            return True
+        try:
+            min_packsize = math.inf
+            max_packsize = -math.inf
+            boss_chance = 0
+            total_weight = 0
+            for pack in monster_packs:
+                weight = pack["Data0"][0]
+                max_boss = pack["BossMonsterCount"]
+                min_boss = max_boss if pack["BossMonsterSpawnChance"] == 100 else 0
+                min_packsize = min(min_packsize, pack["Unknown0"] + pack["Unknown1"] + min_boss)
+                max_packsize = max(max_packsize, pack["Unknown0"] + pack["Unknown2"] + max_boss)
+                total_weight = total_weight + weight
+                boss_chance = boss_chance + weight * pack["BossMonsterSpawnChance"]
+
+            infobox["description"] = "<br>".join(data["Description"].splitlines())
+            infobox["pack_id"] = pack["Id"]
+            if not math.isinf(min_packsize):
+                infobox["pack_min_size"] = min_packsize
+            if not math.isinf(max_packsize):
+                infobox["pack_max_size"] = max_packsize
+            infobox["pack_leader_chance"] = boss_chance = boss_chance / total_weight
+
+        except KeyError:
+            return False
+        return True
+
     def _skill_gem(self, infobox: OrderedDict, base_item_type):
         try:
             skill_gem = self.rr["SkillGems.dat64"].index["BaseItemTypesKey"][base_item_type.rowid]
@@ -3241,42 +3267,6 @@ class ItemsParser(SkillParserShared):
         row_index=True,
     )
 
-    _type_allflame_ember = _type_factory(
-        data_file="ItemisedNecropolisPacks.dat64",
-        index_column="Item",
-        data_mapping=(
-            (
-                "Description",
-                {
-                    "template": "description",
-                    "format": lambda v: "<br>".join(v.splitlines()),
-                },
-            ),
-            (
-                "Pack",
-                {
-                    "template": "pack_description",
-                    "format": lambda v: _markup_to_wiki(v["Description"]),
-                },
-            ),
-            (
-                "Pack",
-                {
-                    "template": "pack_leader_name",
-                    "format": lambda v: _markup_to_wiki(v["PackLeader1"]),
-                },
-            ),
-            (
-                "Pack",
-                {
-                    "template": "pack_leader_description",
-                    "format": lambda v: _markup_to_wiki(v["PackLeader2"]),
-                },
-            ),
-        ),
-        row_index=True,
-    )
-
     _cls_map = dict()
     """
     This defines the expected data elements for an item class.
@@ -3433,7 +3423,7 @@ class ItemsParser(SkillParserShared):
         "HeistObjective": (),
         "Breachstone": (_type_currency,),
         "ItemisedCorpse": (_type_corpse,),
-        "NecropolisPack": (_type_allflame_ember,),
+        "NecropolisPack": (_allflame_ember,),
     }
 
     _conflict_active_skill_gems_map = {

--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -732,9 +732,10 @@ class MOD_DOMAIN(IntEnumOverride):
     TINCTURE = 34
     AFFLICTION_CHARM = 35
     NECROPOLIS_MONSTER = 36
+    UBER_MAP = 37
 
     # Items that can't have mods (may need to increase the number when new values are added)
-    MODS_DISALLOWED = 37
+    MODS_DISALLOWED = 38
 
     # legacy names
     MASTER = CRAFTED

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -1859,15 +1859,13 @@ specification = Specification(
                 ),
                 Field(
                     name="Mainhand_AnimationKey",
-                    type="ref|string",
+                    type="ref|generic",
                     key="Animation.dat",
-                    key_id="Id",
                 ),
                 Field(
                     name="Offhand_AnimationKey",
-                    type="ref|string",
+                    type="ref|generic",
                     key="Animation.dat",
-                    key_id="Id",
                 ),
                 Field(
                     name="Flag3",
@@ -1876,6 +1874,24 @@ specification = Specification(
                 Field(
                     name="Key0",
                     type="ref|out",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="ref|generic",
+                    key="Animation.dat",
+                ),
+                Field(
+                    name="Flag4",
+                    type="bool",
+                ),
+                Field(
+                    name="Unknown1",
+                    type="ref|generic",
+                    key="Animation.dat",
+                ),
+                Field(
+                    name="Data0",
+                    type="ref|list|ref|string",
                 ),
             ),
         ),
@@ -5682,6 +5698,10 @@ specification = Specification(
                 Field(
                     name="Key0",
                     type="ref|out",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="ref|string",
                 ),
             ),
         ),
@@ -9557,6 +9577,10 @@ specification = Specification(
                     name="WordsKey",
                     type="ref|out",
                     key="Words.dat",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
                 ),
             ),
         ),
@@ -15824,6 +15848,10 @@ specification = Specification(
                     name="Flag3",
                     type="bool",
                 ),
+                Field(
+                    name="Flag4",
+                    type="bool",
+                ),
             ),
         ),
         "ItemCostPerLevel.dat": File(
@@ -18519,6 +18547,12 @@ specification = Specification(
                 ),
                 Field(
                     name="UberBlight_DDSFile",
+                    type="ref|string",
+                    file_path=True,
+                    file_ext=".dds",
+                ),
+                Field(
+                    name="Purple_DDSFile",
                     type="ref|string",
                     file_path=True,
                     file_ext=".dds",
@@ -21777,6 +21811,11 @@ specification = Specification(
                     name="Data3",
                     type="ref|list|ref|string",
                 ),
+                Field(
+                    name="NecropolisPack",
+                    type="ref|out",
+                    key="NecropolisPacks.dat",
+                ),
             ),
         ),
         "MonsterProjectileAttack.dat": File(
@@ -23165,8 +23204,12 @@ specification = Specification(
                     type="ref|out",
                 ),
                 Field(
-                    name="Data2",
-                    type="ref|list|byte",
+                    name="Keys2",
+                    type="ref|list|ref|out",
+                ),
+                Field(
+                    name="Key4",
+                    type="ref|out",
                 ),
             ),
         ),
@@ -23643,6 +23686,50 @@ specification = Specification(
                 ),
             ),
         ),
+        "NecropolisCraftBases.dat": File(
+            fields=(
+                Field(
+                    name="Id",
+                    type="ref|string",
+                ),
+                Field(
+                    name="BaseItem",
+                    type="ref|out",
+                    key="BaseItemTypes.dat",
+                ),
+                Field(
+                    name="UniqueCraft",
+                    type="ref|out",
+                    key="NecropolisUniqueCrafts.dat",
+                ),
+                Field(
+                    name="Flag0",
+                    type="bool",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="int",
+                ),
+                Field(
+                    name="CraftItemType",
+                    type="ref|out",
+                    key="NecropolisCraftItemTypes.dat",
+                ),
+                Field(
+                    name="Name",
+                    type="ref|string",
+                ),
+                Field(
+                    name="CraftTag",
+                    type="ref|out",
+                    key="Stats.dat",
+                ),
+                Field(
+                    name="Flag1",
+                    type="bool",
+                ),
+            ),
+        ),
         "NecropolisCraftItemTypes.dat": File(
             fields=(
                 Field(
@@ -23662,35 +23749,13 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Keys0",
-                    type="ref|list|ref|out",
-                ),
-                Field(
                     name="IllustratuionIcon",
                     type="ref|string",
-                ),
-                Field(
-                    name="UniqueCraft",
-                    type="ref|out",
-                    key="NecropolisUniqueCrafts.dat",
-                ),
-                Field(
-                    name="BaseItem",
-                    type="ref|out",
-                    key="BaseItemTypes.dat",
                 ),
                 Field(
                     name="TextAudioLong",
                     type="ref|out",
                     key="NPCTextAudio.dat",
-                ),
-                Field(
-                    name="Flag0",
-                    type="bool",
-                ),
-                Field(
-                    name="Flag1",
-                    type="bool",
                 ),
                 Field(
                     name="Achievements",
@@ -23701,6 +23766,10 @@ specification = Specification(
                     name="TextAudioShort",
                     type="ref|out",
                     key="NPCTextAudio.dat",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
                 ),
             ),
         ),

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -510,7 +510,7 @@ class TranslationString(TranslationReprMixin):
     _REPR_EXTRA_ATTRIBUTES = OrderedDict((("string", None),))
 
     # replacement tags used in translations
-    _re_split = re.compile(r"(?:\{(?P<id>[0-9]*)(?:[\:]*)(?P<type>[^\}]*)\})", re.UNICODE)
+    _re_split = re.compile(r"(?<!>|\{)(?:\{(?P<id>[0-9]*)(?:[\:]*)(?P<type>[^\}]*)\})", re.UNICODE)
 
     def __init__(self, parent: TranslationLanguage):
         parent.strings.append(self)

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -1268,7 +1268,7 @@ class TQRelationalData(TranslationQuantifier):
         table: str,
         index_column: str = None,
         value_column: str = "Name",
-        predicate: (str, Any) = None,
+        predicate: tuple[str, Any] = None,
         placeholder: str = None,
         convert_type: str = None,
     ):
@@ -2611,6 +2611,12 @@ TQNumberFormat(
 
 TranslationQuantifier(
     id="canonical_line",
+    type=TranslationQuantifier.QuantifierTypes.STRING,
+    arg_size=0,
+)
+
+TranslationQuantifier(
+    id="markup",
     type=TranslationQuantifier.QuantifierTypes.STRING,
     arg_size=0,
 )

--- a/export.bash
+++ b/export.bash
@@ -184,6 +184,7 @@ exporting modules && {
   pypoe_exporter $QUIET wiki lua synthesis "${ARGS[@]}" "$@"
   pypoe_exporter $QUIET wiki lua ot "${ARGS[@]}" "$@"
   pypoe_exporter $QUIET wiki lua minimap "${ARGS[@]}" "$@"
+  pypoe_exporter $QUIET wiki lua packs "${ARGS[@]}" "$@"
 }
 exporting atlas-icons &&
 pypoe_exporter $QUIET wiki items atlas_icons "${ARGS[@]}" "$@" --store-images --convert-images


### PR DESCRIPTION
# Abstract

Adds pack and pack leader descriptions to allflame embers.

# Action Taken

The packs associated with allflame embers have text format that is shown when the item is used in the lantern. This adds that text to the exported data, so that this information can be shown on the wiki.