### PR TITLE
Stat text improvements

### DIFF
--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -270,7 +270,7 @@ _inter_wiki_map = {
         # Buffs
         #
         # Charges
-        ("Power, Frenzy or Endurance Charge(?:|s)", {"link": "Charge"}),
+        ("Power, Frenzy (?:and|or) Endurance Charge(?:|s)", {"link": "Charge"}),
         ("Endurance Charge(?:|s)", {"link": "Endurance Charge"}),
         ("Frenzy Charge(?:|s)", {"link": "Frenzy Charge"}),
         ("Power Charge(?:|s)", {"link": "Power Charge"}),
@@ -631,6 +631,7 @@ _inter_wiki_map = {
         ("Curse(?:|s|ed)", {"link": "Curse"}),
         ("Socket(?:|s|ed)", {"link": "Item socket"}),
         ("Recently", {"link": "Recently"}),
+        ("Passive Skill(?:|s)", {"link": "Passive skill"}),
         ("Skill(?:|s)", {"link": "Skill"}),
         ("Spell(?:|s)", {"link": "Spell"}),
         ("Attack(?:|s)", {"link": "Attack"}),
@@ -649,6 +650,7 @@ _inter_wiki_map = {
         ("Unlucky", {"link": "Unlucky"}),
         ("Stationary", {"link": "Stationary"}),
         ("Nearby", {"link": "Nearby"}),
+        ("in your Presence", {"link": "In your presence"}),
         ("Shatter", {"link": "Shatter"}),
         ("Critical Strike(?:|s)", {"link": "Critical strike"}),
         ("Crush(?:|ed)", {"link": "Crushed"}),
@@ -1358,7 +1360,7 @@ def _make_inter_wiki_re():
                     r"(?![^\[]*\]\])"
                     r"(?: |^)"
                     r"(?P<text>%s)"
-                    r"(?= |$)"
+                    r"(?=\W|$)"
                     % "|".join(
                         ["(%s)" % item[0] for item in _inter_wiki_mapping[id : id + _MAX_RE]]
                     ),
@@ -1600,7 +1602,15 @@ class BaseParser:
 
             out = temp_trans
         else:
-            out = [make_inter_wiki_links(line) for line in result.lines]
+            result_lines = result.lines
+            for client_string in result.client_string_formats:
+                format: str = self.rr["ClientStrings.dat64"].index["Id"][client_string]["Text"]
+                # works for now, may need to revisit if different formats are added to _CLIENT_STRINGS_LOOKUP
+                result_lines = (
+                    [format.format(line) for line in result_lines] if result_lines else [format]
+                )
+
+            out = [make_inter_wiki_links(line) for line in result_lines]
 
         if result.missing_ids:
             # Check for a hardcoded result first, using result's missing values.

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -2398,22 +2398,18 @@ class ItemsParser(SkillParserShared):
             infobox["buff_value%s" % i] = value
 
         if flasks["BuffDefinitionsKey"]:
-            stats = [s["Id"] for s in flasks["BuffDefinitionsKey"]["StatsKeys"]]
-            if stats:
-                tr = self.tc["stat_descriptions.txt"].get_translation(
-                    stats,
-                    flasks["BuffStatValues"],
-                    full_result=True,
-                    lang=self._language,
-                )
-            else:
-                stats = [s["Id"] for s in flasks["BuffDefinitionsKey"]["Binary_StatsKeys"]]
-                tr = self.tc["stat_descriptions.txt"].get_translation(
-                    stats,
-                    [1 for _ in stats],
-                    full_result=True,
-                    lang=self._language,
-                )
+            stats = [s["Id"] for s in flasks["BuffDefinitionsKey"]["StatsKeys"]] + [
+                s["Id"] for s in flasks["BuffDefinitionsKey"]["Binary_StatsKeys"]
+            ]
+            values = flasks["BuffStatValues"] + [
+                1 for _ in flasks["BuffDefinitionsKey"]["Binary_StatsKeys"]
+            ]
+            tr = self.tc["stat_descriptions.txt"].get_translation(
+                stats,
+                values,
+                full_result=True,
+                lang=self._language,
+            )
             infobox["buff_stat_text"] = "<br>".join(
                 [parser.make_inter_wiki_links(line) for line in tr.lines]
             )

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -1379,6 +1379,7 @@ class TranslationResult(TranslationReprMixin):
         "extra_strings",
         "string_instances",
         "tf_indices",
+        "client_string_formats",
     ]
 
     def __init__(
@@ -1397,6 +1398,7 @@ class TranslationResult(TranslationReprMixin):
         extra_strings,
         string_instances,
         tf_indices,
+        client_string_formats,
     ):
         self.found: List[Translation] = found
         self.found_lines: List[str] = found_lines
@@ -1412,6 +1414,7 @@ class TranslationResult(TranslationReprMixin):
         self.extra_strings: List[Dict[str, str]] = extra_strings
         self.string_instances: List[TranslationString] = string_instances
         self.tf_indices: List[Union[int, None]] = tf_indices
+        self.client_string_formats: List[str] = client_string_formats
 
     def _get_found_ids(self) -> List[List[str]]:
         """
@@ -1484,6 +1487,12 @@ class TranslationFile(AbstractFileReadOnly):
 
     _VIRTUAL_STAT_LOOKUP = {
         "corrosive_shroud_maximum_stored_poison_damage": "virtual_plague_bearer_maximum_stored_poison_damage"  # noqa
+    }
+
+    _CLIENT_STRINGS_LOOKUP = {
+        "map_is_uber_map": "ItemPopupUnmodifiableExceptChaosOrbs",
+        "local_influence_mod_requires_celestial_boss_presence": "InfluenceStatConditionPresenceCelestialBoss",
+        "local_influence_mod_requires_unique_monster_presence": "InfluenceStatConditionPresenceUniqueMonster",
     }
 
     def __init__(
@@ -1971,6 +1980,11 @@ class TranslationFile(AbstractFileReadOnly):
                 extra_strings=extra_strings,
                 string_instances=string_instances,
                 tf_indices=tf_indices,
+                client_string_formats=[
+                    self._CLIENT_STRINGS_LOOKUP[tag]
+                    for tag in tags
+                    if tag in self._CLIENT_STRINGS_LOOKUP
+                ],
             )
         if only_values:
             return formatted_values


### PR DESCRIPTION
# Abstract

Improvements to stat text generation for mods, passives and flasks

# Action Taken

- Include both binary and a numeric stats for flask text
- Add a lookup step for stat text that is found in ClientStrings.dat
- Change the terminating character for the make_inter_wiki_links regex from ` ` to `\W`, to correctly display links that are followed by a comma or line break

# Caveats

The relation between stats and ClientStrings values does not appear to be found anywhere in the datafiles, and has been implemented as a custom lookup instead.
