### PR TITLE
Tolerate newlines in translation file

### DIFF
--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1676,6 +1676,7 @@ class TagHandler:
     # while the translated name is in Text2
     UNIQ_FORMATS = {
         "Lightpoacher": "[[%s]]",
+        "Grand Spectrum": "[[%s]]",
         "Precursor's Emblem": "[[%s]]",
         "Shroud of the Lightless": "[[%s]]",
         "Thread of Hope": "{{il|page=%s}}",

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -23554,8 +23554,9 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
-                    name="Keys0",
+                    name="NPCs",
                     type="ref|list|ref|out",
+                    key="NPCs.dat",
                 ),
                 Field(
                     name="Key0",

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -155,7 +155,7 @@ regex_translation_string = re.compile(
     r"^"
     r"[\s]*"
     r"(?P<minmax>(?:[0-9\-\|#!]+[ \t]+)+)"
-    r'"(?P<description>.*\s*)"'
+    r'"(?P<description>[^"]*)"'
     r"(?P<quantifier>(?:[ \t]*[\w%]+)*)"
     r"[ \t]*[\r\n]*"
     r"$",
@@ -1662,7 +1662,11 @@ class TranslationFile(AbstractFileReadOnly):
                                     TranslationWarning,
                                 )
 
-                        ts._set_string(ts_match.group("description"))
+                        # assuming that line breaks within the description are just for dev legibility,
+                        # as they seem to be preceded by escaped newlines (literal \n) anyway
+                        ts._set_string(
+                            "".join(s.strip() for s in ts_match.group("description").splitlines())
+                        )
 
                         ts.quantifier.register_from_string(
                             ts_match.group("quantifier"),


### PR DESCRIPTION
# Abstract

Accept strings in the translation file that have a newline between the quotation marks.

# Action Taken

This doesn't appear to affect any of the english-language text exported by pypoe, but as of the recent patch, some translations in other languages have line breaks in them, which was causing the exporter to crash.

# Caveats

This appears to not be semantic as it preceded by a \n escape sequence, which is how newlines are encoded in these files, so the newline is discarded and no space is inserted, but this may turn out to be an incorrect assumption.
