### PR TITLE
Wiki

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -1872,6 +1872,7 @@ class ItemsParser(SkillParserShared):
         "Metadata/Items/Weapons/TwoHandWeapons/Bows/EtherealBow1",
         "Metadata/Items/ItemEffects/SekhemasBanner",
         "Metadata/Items/Armours/BodyArmours/BodyStrTemp",
+        "Metadata/Items/Armours/Boots/BootsStrTemp",
         "Metadata/Items/Classic/MysteryLeaguestone",
         "Metadata/Items/Relics/Relic1x3",
         "Metadata/Items/Relics/Relic1x4",
@@ -1905,6 +1906,9 @@ class ItemsParser(SkillParserShared):
             r"Convert.*Scroll",
             r"Premium.*Pet",
             r"UnifiedAuraEffect",
+        },
+        "InstanceLocalItem": {
+            r".*",
         },
     }
 

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -605,6 +605,8 @@ class ItemsParser(SkillParserShared):
             # =================================================================
             "Metadata/Items/Gems/SkillGemArcaneCloak": "",
             "Metadata/Items/Gems/SkillGemPortal": " (skill gem)",
+            "Metadata/Items/Gems/SkillGemConvocationNew": "",
+            "Metadata/Items/Gems/SkillGemConvocation": " (legacy)",
             # =================================================================
             # Support Gems
             # =================================================================


### PR DESCRIPTION
- Skip "Kaom's Greaves", a dummy/test item.
- Skip all items belonging to "InstanceLocalItem" class. These are used by the trade website. They don't exist as items in game.
- Resolve page name conflict between the current Convocation skill gem and the legacy one.