### PR TITLE
Don't output rarity of unique beasts

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -588,7 +588,7 @@ class BestiaryParser(GenericLuaParser):
 
         for row in self.rr["BestiaryRecipeComponent.dat64"]:
             self._copy_from_keys(row, self._COPY_KEYS_BESTIARY_COMPONENTS, components)
-            if row["BeastRarity"]:
+            if row["BeastRarity"] and row["BeastRarity"]["Id"] != "Unique":
                 display_string = "ItemDisplayString" + row["BeastRarity"]["Id"]
                 client_strings = self.rr["ClientStrings.dat64"].index["Id"]
                 components[-1]["rarity"] = client_strings[display_string]["Text"]


### PR DESCRIPTION
# Abstract

When exporting bestiary components, don't include a 'rarity' key if the value is 'Unique'

# Action Taken

See https://discord.com/channels/872882365406523452/873440137558757407/1244104304114274314

This was causing issues with The Black Morrigan, the only currently capturable creature that has a unique rarity. Unique monsters captured during bestiary league are treated as rares for the purpose of recipes, suggesting that the 'unique' rarity is no longer relevant for bestiary recipes.
