### PR TITLE
Revert "Don't output rarity of unique beasts"

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -588,7 +588,7 @@ class BestiaryParser(GenericLuaParser):
 
         for row in self.rr["BestiaryRecipeComponent.dat64"]:
             self._copy_from_keys(row, self._COPY_KEYS_BESTIARY_COMPONENTS, components)
-            if row["BeastRarity"] and row["BeastRarity"]["Id"] != "Unique":
+            if row["BeastRarity"]:
                 display_string = "ItemDisplayString" + row["BeastRarity"]["Id"]
                 client_strings = self.rr["ClientStrings.dat64"].index["Id"]
                 components[-1]["rarity"] = client_strings[display_string]["Text"]


### PR DESCRIPTION
Reverts Project-Path-of-Exile-Wiki/PyPoE#183

It's better to have PyPoE output the data as it is. The wiki templating can then decide what to do with it.