### PR TITLE
Item template

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -281,26 +281,22 @@ class WikiCondition(parser.WikiCondition):
         r"^(recipe|sell_price|implicit[0-9]+_(?:text|random_list)).*", re.UNICODE
     )
 
-    NAME = "Base item"
+    NAME = "Item"
     INDENT = 40
     ADD_INCLUDE = False
 
 
 class ItemWikiCondition(WikiCondition):
-    NAME = "Base item"
+    NAME = "Item"
 
 
 class MapItemWikiCondition(WikiCondition):
-    NAME = "Base item"
+    NAME = "Item"
 
 
 class UniqueMapItemWikiCondition(MapItemWikiCondition):
     NAME = "Item"
     COPY_MATCH = re.compile(r"^(recipe|(ex|im)plicit[0-9]+_(?:text|random_list)).*", re.UNICODE)
-
-
-class ProphecyWikiCondition(WikiCondition):
-    NAME = "Item"
 
 
 class ItemsHandler(ExporterHandler):


### PR DESCRIPTION
Template:Base item has always been functionally equivalent to Template:Item. There's no reason to use two different templates that do the same thing.