### PR TITLE
add custom links for divination cards

### DIFF
--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -260,6 +260,7 @@ _inter_wiki_map = {
         ("Low Mana", {"link": "Low Mana"}),
         ("Full Mana", {"link": "Full Mana"}),
         ("Mana", {"link": "Mana"}),
+        ("Ward", {"link": "Ward"}),
         #
         ("Chaos Resistance(?:|s)", {"link": "Chaos Resistance"}),
         ("Cold Resistance(?:|s)", {"link": "Cold Resistance"}),
@@ -1685,6 +1686,14 @@ class TagHandler:
         "Aul's Uprising": "[[%s]]",
     }
 
+    CUSTOM_LINKS = {
+        "Cartography Scarab": "[[Cartography Scarab (disambiguation)]]",
+        "Divination Scarab": "[[Divination Scarab (disambiguation)]]",
+        "Bestiary Scarab": "[[Bestiary Scarab (disambiguation)]]",
+        "Sulphite Scarab": "[[Sulphite Scarab (disambiguation)]]",
+        "Einhar's Memory of Harvest Beasts": "{{il|Einhar's Memory}}",
+    }
+
     def __init__(self, rr):
         """
         Parameters
@@ -1702,6 +1711,8 @@ class TagHandler:
             self.tag_handlers[key] = partial(func, self)
 
     def _check_link(self, string):
+        if string in self.CUSTOM_LINKS:
+            return self.CUSTOM_LINKS[string]
         if any(category["Text"] == string for category in self.rr["ItemClassCategories.dat64"]):
             return "[[%s]]" % string
         items = self.rr["BaseItemTypes.dat64"].index["Name"][string]

--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -1687,11 +1687,11 @@ class TagHandler:
     }
 
     CUSTOM_LINKS = {
-        "Cartography Scarab": "[[Cartography Scarab (disambiguation)]]",
-        "Divination Scarab": "[[Divination Scarab (disambiguation)]]",
-        "Bestiary Scarab": "[[Bestiary Scarab (disambiguation)]]",
-        "Sulphite Scarab": "[[Sulphite Scarab (disambiguation)]]",
-        "Einhar's Memory of Harvest Beasts": "{{il|Einhar's Memory}}",
+        "Cartography Scarab": "[[Cartography Scarab (disambiguation)|Cartography Scarab]]",
+        "Divination Scarab": "[[Divination Scarab (disambiguation)|Divination Scarab]]",
+        "Bestiary Scarab": "[[Bestiary Scarab (disambiguation)|Bestiary Scarab]]",
+        "Sulphite Scarab": "[[Sulphite Scarab (disambiguation)|Sulphite Scarab]]",
+        "Einhar's Memory of Harvest Beasts": "{{il|html=|Einhar's Memory|Einhar's Memory of Harvest Beasts}}",
     }
 
     def __init__(self, rr):

--- a/PyPoE/cli/exporter/wiki/parser.py
+++ b/PyPoE/cli/exporter/wiki/parser.py
@@ -260,7 +260,7 @@ _inter_wiki_map = {
         ("Low Mana", {"link": "Low Mana"}),
         ("Full Mana", {"link": "Full Mana"}),
         ("Mana", {"link": "Mana"}),
-        ("Ward", {"link": "Ward"}),
+        ("(?<!stical |during |werful |Wicked )Ward", {"link": "Ward"}),
         #
         ("Chaos Resistance(?:|s)", {"link": "Chaos Resistance"}),
         ("Cold Resistance(?:|s)", {"link": "Cold Resistance"}),


### PR DESCRIPTION
# Abstract

Divination cards that rewarded a class of scarab were linking to the base scarab of that type, if one exists.

# Action Taken

Added a custom dictionary of pages to link to; if a divination card rewards any key of the map it will use the associated link text rather than any other heuristic.

# Caveats

This dictionary will need to be maintained by hand. There may be a better way to do this; l haven't had a lot of time to explore the data.