### PR TITLE
Sentinels

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -496,22 +496,8 @@ class ItemsParser(SkillParserShared):
     _IGNORE_DROP_LEVEL_CLASSES = (
         "HideoutDoodad",
         "Microtransaction",
-        "LabyrinthItem",
-        "LabyrinthTrinket",
-        "LabyrinthMapItem",
+        "InstanceLocalItem",
     )
-
-    _IGNORE_DROP_LEVEL_ITEMS_BY_ID = {
-        # Alchemy Shard
-        "Metadata/Items/Currency/CurrencyUpgradeToRareShard",
-        # Alteration Shard
-        "Metadata/Items/Currency/CurrencyRerollMagicShard",
-        "Metadata/Items/Currency/CurrencyLabyrinthEnchant",
-        "Metadata/Items/Currency/CurrencyImprint",
-        # Transmute Shard
-        "Metadata/Items/Currency/CurrencyUpgradeToMagicShard",
-        "Metadata/Items/Currency/CurrencyIdentificationShard",
-    }
 
     _DROP_DISABLED_ITEMS_BY_ID = {
         "Metadata/Items/Quivers/Quiver1",
@@ -1633,6 +1619,7 @@ class ItemsParser(SkillParserShared):
         # Currency items
         # =================================================================
         "Metadata/Items/Currency/CurrencySilverCoin",
+        "Metadata/Items/Currency/CurrencyLabyrinthEnchant",
         # =================================================================
         # Non-stackable resonators from before 3.8.0
         # =================================================================
@@ -3744,10 +3731,7 @@ class ItemsParser(SkillParserShared):
                 text=base_item_type["FlavourTextKey"]["Text"],
             )
 
-        if (
-            base_item_type["ItemClassesKey"]["Id"] not in self._IGNORE_DROP_LEVEL_CLASSES
-            and m_id not in self._IGNORE_DROP_LEVEL_ITEMS_BY_ID
-        ):
+        if base_item_type["ItemClassesKey"]["Id"] not in self._IGNORE_DROP_LEVEL_CLASSES:
             infobox["drop_level"] = base_item_type["DropLevel"]
 
         base_ot = ITFile(parent_or_file_system=self.file_system)

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -267,12 +267,8 @@ class WikiCondition(parser.WikiCondition):
         "quest_reward4_class_ids",
         "quest_reward4_npc",
         # Sentinels
-        "sentinel_duration",
-        "sentinel_empowers",
-        "sentinel_empowerment",
         "sentinel_monster",
         "sentinel_monster_level",
-        "sentinel_charge",
     )
     COPY_MATCH = re.compile(
         r"^(recipe|sell_price|implicit[0-9]+_(?:text|random_list)).*", re.UNICODE

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -3319,6 +3319,42 @@ class ItemsParser(SkillParserShared):
         row_index=True,
     )
 
+    _type_sentinel = _type_factory(
+        data_file="DroneBaseTypes.dat64",
+        index_column="BaseType",
+        data_mapping=(
+            (
+                "Charges",
+                {
+                    "template": "sentinel_charge",
+                    "condition": lambda v: v,
+                },
+            ),
+            (
+                "Duration",
+                {
+                    "template": "sentinel_duration",
+                    "condition": lambda v: v,
+                },
+            ),
+            (
+                "EnemyLimit",
+                {
+                    "template": "sentinel_empowers",
+                    "condition": lambda v: v,
+                },
+            ),
+            (
+                "Empowerment",
+                {
+                    "template": "sentinel_empowerment",
+                    "condition": lambda v: v,
+                },
+            ),
+        ),
+        row_index=True,
+    )
+
     _cls_map = dict()
     """
     This defines the expected data elements for an item class.
@@ -3482,6 +3518,7 @@ class ItemsParser(SkillParserShared):
             _type_tincture,
         ),
         "Gold": (_type_currency,),
+        "SentinelDrone": (_type_sentinel,),
     }
 
     _conflict_active_skill_gems_map = {

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -7436,6 +7436,53 @@ specification = Specification(
                 ),
             ),
         ),
+        "CurrencyExchange.dat": File(
+            fields=(
+                Field(
+                    name="Item",
+                    type="ref|out",
+                    key="BaseItemTypes.dat",
+                ),
+                Field(
+                    name="Category",
+                    type="ref|out",
+                    key="CurrencyExchangeCategories.dat",
+                ),
+                Field(
+                    name="SubCategory",
+                    type="ref|out",
+                    key="CurrencyExchangeCategories.dat",
+                ),
+                Field(
+                    name="Flag0",
+                    type="bool",
+                ),
+                Field(
+                    name="EnabledInChallengeLeague",
+                    type="bool",
+                ),
+                Field(
+                    name="GoldPurchaseFee",
+                    type="int",
+                ),
+                Field(
+                    name="Flag1",
+                    type="bool",
+                ),
+            ),
+        ),
+        "CurrencyExchangeCategories.dat": File(
+            fields=(
+                Field(
+                    name="Id",
+                    type="ref|string",
+                ),
+                Field(
+                    name="Name",
+                    type="ref|string",
+                ),
+            ),
+        ),
         "CurrencyItems.dat": File(
             fields=(
                 Field(
@@ -9048,6 +9095,7 @@ specification = Specification(
                     name="BaseType",
                     type="ref|out",
                     key="BaseItemTypes.dat",
+                    unique=True,
                 ),
                 Field(
                     name="Type",
@@ -16546,6 +16594,18 @@ specification = Specification(
                 Field(
                     name="Key3",
                     type="ref|out",
+                ),
+                Field(
+                    name="Keys1",
+                    type="ref|list|ref|out",
+                ),
+                Field(
+                    name="Keys2",
+                    type="ref|list|ref|out",
+                ),
+                Field(
+                    name="Flag2",
+                    type="bool",
                 ),
             ),
         ),
@@ -24582,6 +24642,10 @@ specification = Specification(
                     name="AchievementItem",
                     type="ref|out",
                     key="AchievementItems.dat",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
                 ),
             ),
             virtual_fields=(


### PR DESCRIPTION
Fields for sentinels can now be exported.

Also, revised items for which drop level is ignored. We do not want to export drop_level for things like hideout decorations and cosmetic items. For everything else, export drop_level and let the wiki templating decide what to do with it.