### PR TITLE
skip translations containing only restricted strings

### DIFF
--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -1697,7 +1697,7 @@ class TranslationFile(AbstractFileReadOnly):
                         all_strings_restricted = True
                     offset = offset_next_lang
 
-				# since translation strings with restrictions are skipped when resolving translations,
+                # since translation strings with restrictions are skipped when resolving translations,
                 # don't track the root translation at all in order to allow a subsequent unrestricted
                 # translation to be matched
                 if not all_strings_restricted:

--- a/PyPoE/poe/file/translations.py
+++ b/PyPoE/poe/file/translations.py
@@ -1619,6 +1619,7 @@ class TranslationFile(AbstractFileReadOnly):
                 t = True
                 language = "English"
                 while t:
+                    all_strings_restricted = False
                     tl = TranslationLanguage(language, parent=translation)
                     tcount = regex_int.search(data, offset, offset_max)
                     offset = tcount.end()
@@ -1692,11 +1693,17 @@ class TranslationFile(AbstractFileReadOnly):
                             ts_match.group("quantifier"),
                         )
 
+                    if not [s for s in tl.strings if not s.restrictions]:
+                        all_strings_restricted = True
                     offset = offset_next_lang
 
-                self.translations.append(translation)
-                for translation_id in translation.ids:
-                    self._add_translation_hashed(translation_id, translation)
+				# since translation strings with restrictions are skipped when resolving translations,
+                # don't track the root translation at all in order to allow a subsequent unrestricted
+                # translation to be matched
+                if not all_strings_restricted:
+                    self.translations.append(translation)
+                    for translation_id in translation.ids:
+                        self._add_translation_hashed(translation_id, translation)
                 translation_index += 1
 
             elif match.group("no_description"):


### PR DESCRIPTION
# Abstract

Since translation strings with restrictions are skipped when resolving translations, don't cache the root translation at all in order to allow a subsequent unrestricted translation to be matched.

# Action Taken

When reading a translation file, after completing a translation "block", see if every "translation string" in that block (for a single language) has "restrictions". If every string has a restriction, do not store the translation so it is not used during translation resolution.

# Caveats

In the event someone might need these restricted (`table_only`, I'm guessing the game uses these to implement the skill panel) translations, the translation objects would not have them at all. I thought about possibly making this "skipping" behavior more dynamic by changing the implementation of `get_translation()`, but skipping the translation in the file reading phase was definitely the simpler approach.
