### PR TITLE
Add support for atlas_div_cards column

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/area.py
+++ b/PyPoE/cli/exporter/wiki/parsers/area.py
@@ -377,6 +377,13 @@ class AreaParser(parser.BaseParser):
                     "default": False,
                 },
             ),
+            (
+                "DivCards",
+                {
+                    "template": "atlas_div_cards",
+                    "default": False,
+                },
+            ),
         )
     )
 

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -4355,6 +4355,10 @@ class ItemsParser(SkillParserShared):
                         infobox["atlas_connection%s_target" % i] = k
                         infobox["atlas_connection%s_tier" % i] = ", ".join(v)
 
+                    infobox["atlas_div_cards"] = ", ".join(
+                        card["Id"] for card in atlas_node["DivCards"]
+                    )
+
                 infobox["flavour_text"] = (
                     atlas_node["FlavourTextKey"]["Text"].replace("\n", "<br>").replace("\r", "")
                 )

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -2393,6 +2393,11 @@ specification = Specification(
                     name="Unknown5",
                     type="int",
                 ),
+                Field(
+                    name="DivCards",
+                    type="ref|list|ref|out",
+                    key="BaseItemTypes.dat",
+                ),
             ),
         ),
         "AtlasNodeDefinition.dat": File(


### PR DESCRIPTION
# Abstract

Adds support for exporting DivCards as `atlas_div_cards` table column for poewiki from AtlasNode.dat

# Action Taken

Added mapping for DivCards column, added exporting for DivCards column as atlas_div_cards column for poe wiki

# Caveats

I am not sure if the area modifications are necessary and I am not sure if the `type` is correct, copied it from similar column in poe2 AtlasNode specification, so i am like 80% sure its correct, but not 100%.

Also obviously wiki would need to be adjusted too to support this new column i guess