### PR TITLE
Add better version info to page edit comment

### DIFF
--- a/PyPoE/cli/exporter/poe2wiki/handler.py
+++ b/PyPoE/cli/exporter/poe2wiki/handler.py
@@ -30,6 +30,7 @@ See PyPoE/LICENSE
 # =============================================================================
 
 import os
+import re
 import sys
 import time
 from collections.abc import Iterable
@@ -53,7 +54,7 @@ except Exception:
 from PyPoE import __version__
 from PyPoE.cli.core import Msg, console
 from PyPoE.cli.exporter import config
-from PyPoE.cli.exporter.util import fix_path
+from PyPoE.cli.exporter.util import fix_path, get_content_path
 from PyPoE.cli.handler import BaseHandler
 
 # =============================================================================
@@ -268,7 +269,10 @@ class WikiHandler:
                     response = page.save(
                         text=text,
                         summary="PyPoE/ExporterBot/%s: %s"
-                        % (__version__, self.cmdargs.wiki_message or row["wiki_message"]),
+                        % (
+                            self.get_version_string(),
+                            self.cmdargs.wiki_message or row["wiki_message"],
+                        ),
                     )
                 if response["result"] == "Success":
                     console(
@@ -291,6 +295,59 @@ class WikiHandler:
                 out_path = os.path.join(self.out_dir, "diff", fix_path(row["out_file"]))
                 with open(out_path + ".skip", "w") as f:
                     f.write("\n".join(p["page"] for p in pages))
+
+    def get_version_string(self) -> str:
+        if hasattr(self, "_version_string") and self._version_string:
+            return self._version_string
+
+        try:
+            import subprocess
+
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            if status.stdout.strip():
+                while True:
+                    ans = (
+                        input(
+                            "Uncommitted changes detected in the repository. "
+                            "Please do not update the wiki before merging your change into the main github repo. "
+                            "Continue? [y/n]: "
+                        )
+                        .strip()
+                        .lower()
+                    )
+                    if ans in ("y", "yes"):
+                        break
+                    if ans in ("n", "no"):
+                        raise SystemExit("Aborted due to uncommitted changes.")
+
+            self._version_string = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+            ).stdout.strip()
+
+        except Exception as e:
+            console(f"Failed to get commit hash: {e}", msg=Msg.error)
+            self._version_string = __version__
+
+        try:
+            if self.cmdargs.game_version:
+                self._version_string += f" (game version {self.cmdargs.game_version})"
+            else:
+                ggpk_path = get_content_path(2)
+                if ggpk_path.startswith("https://"):
+                    pattern = re.compile(r"^\d+(?:\.\d+){2,}$")
+                    for seg in ggpk_path.split("/"):
+                        if pattern.match(seg):
+                            self._version_string += f" (game version {seg})"
+                            break
+        except Exception as e:
+            console(f"Failed to get game version: {e}", msg=Msg.error)
+
+        return self._version_string
 
     def handle(self, *a, mwclient, result, cmdargs, parser, out_dir):
         # First row is handled separately to prompt the user for his password
@@ -316,6 +373,9 @@ class WikiHandler:
         self.pages_to_recache = SimpleQueue()
         self.print_lock = Lock()
         self.write_lock = Lock()
+
+        if not cmdargs.dry_run:
+            console(f"Exporting wiki pages with comment `{self.get_version_string()}`")
 
         if cmdargs.wiki_threads > 1:
             console("Starting thread pool...")
@@ -678,6 +738,19 @@ def add_parser_arguments(parser):
         "--wiki-edit-message",
         dest="wiki_message",
         help="Override the default edit message",
+        action="store",
+        type=str,
+        default="",
+    )
+
+    parser.add_argument(
+        "-gv",
+        "--game-version",
+        dest="game_version",
+        help=(
+            "Specify the game version to include in the edit summary (e.g., 3.27.4.2). "
+            "If omitted, the version is inferred from the CDN URL when possible."
+        ),
         action="store",
         type=str,
         default="",

--- a/PyPoE/cli/exporter/wiki/handler.py
+++ b/PyPoE/cli/exporter/wiki/handler.py
@@ -30,6 +30,7 @@ See PyPoE/LICENSE
 # =============================================================================
 
 import os
+import re
 import sys
 import time
 from collections.abc import Iterable
@@ -53,7 +54,7 @@ except Exception:
 from PyPoE import __version__
 from PyPoE.cli.core import Msg, console
 from PyPoE.cli.exporter import config
-from PyPoE.cli.exporter.util import fix_path
+from PyPoE.cli.exporter.util import fix_path, get_content_path
 from PyPoE.cli.handler import BaseHandler
 
 # =============================================================================
@@ -282,7 +283,10 @@ class WikiHandler:
                     response = page.save(
                         text=text,
                         summary="PyPoE/ExporterBot/%s: %s"
-                        % (__version__, self.cmdargs.wiki_message or row["wiki_message"]),
+                        % (
+                            self.get_version_string(),
+                            self.cmdargs.wiki_message or row["wiki_message"],
+                        ),
                     )
                 if response["result"] == "Success":
                     console(
@@ -305,6 +309,59 @@ class WikiHandler:
                 out_path = os.path.join(self.out_dir, "diff", fix_path(row["out_file"]))
                 with open(out_path + ".skip", "w") as f:
                     f.write("\n".join(p["page"] for p in pages))
+
+    def get_version_string(self) -> str:
+        if hasattr(self, "_version_string") and self._version_string:
+            return self._version_string
+
+        try:
+            import subprocess
+
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            if status.stdout.strip():
+                while True:
+                    ans = (
+                        input(
+                            "Uncommitted changes detected in the repository. "
+                            "Please do not update the wiki before merging your change into the main github repo. "
+                            "Continue? [y/n]: "
+                        )
+                        .strip()
+                        .lower()
+                    )
+                    if ans in ("y", "yes"):
+                        break
+                    if ans in ("n", "no"):
+                        raise SystemExit("Aborted due to uncommitted changes.")
+
+            self._version_string = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+            ).stdout.strip()
+
+        except Exception as e:
+            console(f"Failed to get commit hash: {e}", msg=Msg.error)
+            self._version_string = __version__
+
+        try:
+            if self.cmdargs.game_version:
+                self._version_string += f" (game version {self.cmdargs.game_version})"
+            else:
+                ggpk_path = get_content_path(1)
+                if ggpk_path.startswith("https://"):
+                    pattern = re.compile(r"^\d+(?:\.\d+){2,}$")
+                    for seg in ggpk_path.split("/"):
+                        if pattern.match(seg):
+                            self._version_string += f" (game version {seg})"
+                            break
+        except Exception as e:
+            console(f"Failed to get game version: {e}", msg=Msg.error)
+
+        return self._version_string
 
     def handle(self, *a, mwclient, result, cmdargs, parser, out_dir):
         # First row is handled separately to prompt the user for his password
@@ -330,6 +387,9 @@ class WikiHandler:
         self.pages_to_recache = SimpleQueue()
         self.print_lock = Lock()
         self.write_lock = Lock()
+
+        if not cmdargs.dry_run:
+            console(f"Exporting wiki pages with comment `{self.get_version_string()}`")
 
         if cmdargs.wiki_threads > 1:
             console("Starting thread pool...")
@@ -692,6 +752,19 @@ def add_parser_arguments(parser):
         "--wiki-edit-message",
         dest="wiki_message",
         help="Override the default edit message",
+        action="store",
+        type=str,
+        default="",
+    )
+
+    parser.add_argument(
+        "-gv",
+        "--game-version",
+        dest="game_version",
+        help=(
+            "Specify the game version to include in the edit summary (e.g., 3.27.4.2). "
+            "If omitted, the version is inferred from the CDN URL when possible."
+        ),
         action="store",
         type=str,
         default="",

--- a/PyPoE/cli/exporter/wiki/parsers/lua.py
+++ b/PyPoE/cli/exporter/wiki/parsers/lua.py
@@ -313,6 +313,118 @@ class LuaHandler(ExporterHandler):
             func=MinimapIconsParser.main,
         )
 
+        parser = lua_sub.add_parser(
+            "map_series",
+            help="Extract map series information",
+        )
+        self.add_default_parsers(
+            parser=parser,
+            cls=MapSeriesParser,
+            func=MapSeriesParser.main,
+        )
+        group = parser.add_mutually_exclusive_group(required=False)
+        group.add_argument(
+            "-ms",
+            "--map-series",
+            "--filter-map-series",
+            help="Filter by map series name (localized)",
+            dest="map_series",
+        )
+        group.add_argument(
+            "-msid",
+            "--map-series-id",
+            "--filter-map-series-id",
+            help="Filter by internal map series id",
+            dest="map_series_id",
+        )
+
+
+class MapSeriesParser(GenericLuaParser):
+    _files = [
+        "MapSeries.datc64",
+        "MapSeriesTiers.datc64",
+        "AtlasNode.datc64",
+        "Maps.datc64",
+        "WorldAreas.datc64",
+        "BaseItemTypes.datc64",
+    ]
+
+    def has_tier_data(self, series_id):
+        return f"{series_id}Tier" in self.rr["MapSeriesTiers.dat64"].specification.columns_all
+
+    def main(self, parsed_args):
+        if parsed_args.map_series_id:
+            if not self.has_tier_data(parsed_args.map_series_id):
+                # should we bail out here or is there anything to export for Atlas of Worlds and before?
+                raise Exception(f"Tier data not available for {parsed_args.map_series}")
+            self.rr["MapSeries.dat64"].build_index("Id")
+            series = self.rr["MapSeries.dat64"].index["Id"][parsed_args.map_series_id]
+        elif parsed_args.map_series:
+            self.rr["MapSeries.dat64"].build_index("Name")
+            series_rows = self.rr["MapSeries.dat64"].index["Name"][parsed_args.map_series]
+            if not series_rows:
+                raise Exception(f"No tier found with name {parsed_args.map_series}")
+            if not self.has_tier_data(series_rows[0]["Id"]):
+                raise Exception(f"Tier data not available for {parsed_args.map_series}")
+            series = series_rows[0]
+        else:
+            series = self.rr["MapSeries.dat64"][-1]
+
+        self.rr["AtlasNode.dat64"].build_index("WorldAreasKey")
+
+        r = ExporterResult()
+
+        series_id = series["Id"]
+
+        output = []
+
+        for tier in self.rr["MapSeriesTiers.dat64"]:
+            tier_number = tier[f"{series_id}Tier"]
+            if tier_number == 0:
+                continue
+
+            map_base = tier["MapsKey"]
+
+            for world_area in (
+                map_base["Regular_WorldAreasKey"],
+                map_base["Unique_WorldAreasKey"],
+            ):
+                if not world_area:
+                    continue
+                node_data = {
+                    "world_area": world_area["Id"],
+                    "base_item": map_base["BaseItemTypesKey"]["Id"],
+                    "tier": tier_number,
+                }
+                output.append(node_data)
+
+                if series != self.rr["MapSeries.dat64"][-1]:
+                    # AtlasNode.dat only contains data for current series
+                    continue
+
+                atlas_node = self.rr["AtlasNode.dat64"].index["WorldAreasKey"][world_area]
+                if atlas_node:
+                    atlas_node = atlas_node[0]
+                    node_data["connections"] = [
+                        conn["WorldAreasKey"]["Id"] for conn in atlas_node["AtlasNodeKeys"]
+                    ]
+                    node_data["flavour_text"] = atlas_node["FlavourTextKey"]["Text"]
+                    node_data["not_on_atlas"] = atlas_node["NotOnAtlas"]
+                    node_data["div_cards"] = [card["Id"] for card in atlas_node["DivCards"]]
+
+        r.add_result(
+            text=LuaFormatter.format_module(sorted(output, key=lambda x: x["world_area"])),
+            out_file="map_series_%s.lua" % series_id,
+            wiki_page=[
+                {
+                    "page": "Module:MapSeries/%s" % series_id,
+                    "condition": None,
+                }
+            ],
+        )
+
+        return r
+
 
 class MinimapIconsParser(GenericLuaParser):
     _files = [

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -14880,9 +14880,9 @@ specification = Specification(
         "HideoutDoodads.dat": File(
             fields=(
                 Field(
-                    name="BaseItemTypesKey",
+                    name="MtxTypeGameSpecific",
                     type="ref|out",
-                    key="BaseItemTypes.dat",
+                    key="MtxTypeGameSpecific.dat",
                     unique=True,
                 ),
                 Field(
@@ -20016,10 +20016,15 @@ specification = Specification(
                 Field(
                     name="Id",
                     type="int",
+                    unique=True,
                 ),
                 Field(
                     name="Name",
                     type="ref|string",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="int",
                 ),
             ),
         ),
@@ -23498,6 +23503,7 @@ specification = Specification(
                     name="Type",
                     type="ref|out",
                     key="MtxTypes.dat",
+                    unique=True,
                 ),
                 Field(
                     name="HASH16",
@@ -23510,12 +23516,18 @@ specification = Specification(
                     file_ext=".dds",
                 ),
                 Field(
-                    name="Unknown0",
+                    name="Category",
                     type="int",
+                    key="MicrotransactionCategory.dat",
+                    key_id="Id",
                 ),
                 Field(
                     name="Data0",
                     type="ref|list|int",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="int",
                 ),
             ),
         ),
@@ -23563,8 +23575,9 @@ specification = Specification(
                     type="ref|out",
                 ),
                 Field(
-                    name="Key2",
+                    name="ShopTag",
                     type="ref|out",
+                    key="ShopTag.dat",
                 ),
                 Field(
                     name="Unknown3",

--- a/export.bash
+++ b/export.bash
@@ -189,6 +189,7 @@ exporting modules && {
     pypoe_exporter $QUIET $WIKI lua pantheon "${ARGS[@]}" "$@"
     pypoe_exporter $QUIET $WIKI lua synthesis "${ARGS[@]}" "$@"
     pypoe_exporter $QUIET $WIKI lua minimap "${ARGS[@]}" "$@"
+    pypoe_exporter $QUIET $WIKI lua map_series "${ARGS[@]}" "$@"
   elif [ "$WIKI" = "poe2wiki" ]; then
     # Run only for poe2
     pypoe_exporter $QUIET $WIKI lua keywords "${ARGS[@]}" "$@"


### PR DESCRIPTION
# Abstract

Adds the current pypoe git revision and game version to the edit message when updating pages.

# Action Taken

Before any page is edited the updater first checks if there are unstaged commits; if any are found, a warning is printed requesting that the user ensure any changes are merged to the main repo before exporting data. Next, the short commit hash is obtained from git rev-parse, and the game version is appended if known (either because the user added a `--game-version` cli argument or when the exporter is using the cdn as its ggpk_path). If this fails the exporter reverts to the current hard-coded version string.

# Caveats

The warning message printed on unstaged commits pauses waiting for confirmation to proceed; which may be annoying if the user has a legitimate reason to leave uncommitted files in their git repo.
