### PR TITLE
Removed int_id template param

### DIFF
--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -138,13 +138,6 @@ class PassiveSkillParser(parser.BaseParser):
             },
         ),
         (
-            "PassiveSkillGraphId",
-            {
-                "template": "int_id",
-                "format": normalize,
-            },
-        ),
-        (
             "Name",
             {
                 "template": "name",
@@ -601,8 +594,6 @@ class AlternatePassiveSkillParser(parser.BaseParser):
                     data["is_keystone"] = True
                 elif passive["PassiveType"][i] == 3:
                     data["is_notable"] = True
-
-            data["int_id"] = 0
 
             # Handle icon paths
             if passive["DDSIcon"]:


### PR DESCRIPTION
Removed the `int_id` template parameter from the passive skill export. This parameter contained the internal numeric ID of the passive skill node in the graph (the passive skill tree). It's not useful information for players, nor is it used anywhere on the wiki.