### PR TITLE
Schema update for 3.28.0

### DIFF
--- a/PyPoE/cli/exporter/poe2wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/poe2wiki/parsers/item.py
@@ -101,22 +101,6 @@ def _linear_to_srgb(img):
     )
 
 
-def _apply_column_map(
-    infobox, column_map: tuple[tuple[str, dict], ...], list_object: DatRecord | list[DatRecord]
-):
-    if not isinstance(list_object, DatRecord):
-        list_object = list_object[0]
-
-    for k, data in column_map:
-        value = list_object[k]
-        if data.get("condition") and not data["condition"](value):
-            continue
-
-        if data.get("format"):
-            value = data["format"](value)
-        infobox[data["template"]] = value
-
-
 def _skip(*_):
     return False
 
@@ -156,7 +140,7 @@ def _type_factory(
                 else:
                     raise Exception(f"Multiple matches found for {base_item_type['Id']}")
 
-        _apply_column_map(infobox, data_mapping, data)
+        parser.apply_simple_column_map(infobox, data_mapping, data)
 
         if function:
             function(self, infobox, base_item_type, data)

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -93,17 +93,6 @@ def _linear_to_srgb(img):
     )
 
 
-def _apply_column_map(infobox, column_map: tuple[tuple[str, dict], ...], list_object):
-    for k, data in column_map:
-        value = list_object[k]
-        if data.get("condition") and not data["condition"](value):
-            continue
-
-        if data.get("format"):
-            value = data["format"](value)
-        infobox[data["template"]] = value
-
-
 def _type_factory(
     data_file: str,
     data_mapping: tuple[tuple[str, dict], ...],
@@ -130,7 +119,7 @@ def _type_factory(
                     warnings.warn(f'Missing {data_file} info for "{base_item_type["Name"]}"')
                 return fail_condition
 
-        _apply_column_map(infobox, data_mapping, data)
+        parser.apply_simple_column_map(infobox, data_mapping, data)
 
         if function:
             function(self, infobox, base_item_type, data)
@@ -2825,7 +2814,7 @@ class ItemsParser(SkillParserShared):
             harvest_object.rowid
         ]
 
-        _apply_column_map(
+        parser.apply_simple_column_map(
             infobox,
             (
                 (
@@ -2919,7 +2908,7 @@ class ItemsParser(SkillParserShared):
             harvest_object.rowid
         ]
 
-        _apply_column_map(
+        parser.apply_simple_column_map(
             infobox,
             (
                 (

--- a/PyPoE/cli/exporter/wiki/parsers/item.py
+++ b/PyPoE/cli/exporter/wiki/parsers/item.py
@@ -23,9 +23,6 @@ Agreement
 ===============================================================================
 
 See PyPoE/LICENSE
-
-# TODO
-Kishara's Star (item)
 """
 
 # =============================================================================
@@ -235,40 +232,13 @@ class WikiCondition(parser.WikiCondition):
         # prophecies
         "prophecy_objective",
         "prophecy_reward",
-        # Quest Rewards
-        "quest_reward1_type",
-        "quest_reward1_quest",
-        "quest_reward1_quest_id",
-        "quest_reward1_act",
-        "quest_reward1_class_ids",
-        "quest_reward1_npc",
-        "quest_reward2_type",
-        "quest_reward2_quest",
-        "quest_reward2_quest_id",
-        "quest_reward2_act",
-        "quest_reward2_class_ids",
-        "quest_reward2_npc",
-        "quest_reward3_type",
-        "quest_reward3_quest",
-        "quest_reward3_quest_id",
-        "quest_reward3_act",
-        "quest_reward3_class_ids",
-        "quest_reward3_npc",
-        "quest_reward4_type",
-        "quest_reward4_quest",
-        "quest_reward4_quest_id",
-        "quest_reward4_act",
-        "quest_reward4_class_ids",
-        "quest_reward4_npc",
         # Sentinels
         "sentinel_monster",
         "sentinel_monster_level",
     )
+
     COPY_MATCH = re.compile(
-        r"^(recipe|sell_price|implicit[0-9]+_(?:text|random_list)).*", re.UNICODE
-    )
-    COPY_MATCH = re.compile(
-        r"^(recipe|sell_price|implicit[0-9]+_(?:text|random_list)).*", re.UNICODE
+        r"^(quest_reward|recipe|sell_price|implicit[0-9]+_(?:text|random_list)).*", re.UNICODE
     )
 
     NAME = "Item"
@@ -391,7 +361,7 @@ class ItemsParser(SkillParserShared):
         "InstanceLocalItem",
     )
 
-    _DROP_DISABLED_ITEMS_BY_ID = {}
+    _DROP_DISABLED_ITEMS_BY_ID = set()
 
     _EXCLUDE_CLASSES = {
         "Map",
@@ -668,6 +638,7 @@ class ItemsParser(SkillParserShared):
             "Metadata/Items/QuestItems/GoldenPages/Page2": " (2 of 4)",
             "Metadata/Items/QuestItems/GoldenPages/Page3": " (3 of 4)",
             "Metadata/Items/QuestItems/GoldenPages/Page4": " (4 of 4)",
+            "Metadata/Items/QuestItems/Act7/KisharaStar": " (quest item)",
             # =================================================================
             # Heist equipment
             # =================================================================
@@ -3130,7 +3101,6 @@ class ItemsParser(SkillParserShared):
                 break
         return True
 
-    _cls_map = dict()
     """
     This defines the expected data elements for an item class.
     """

--- a/PyPoE/cli/exporter/wiki/parsers/passives.py
+++ b/PyPoE/cli/exporter/wiki/parsers/passives.py
@@ -452,23 +452,24 @@ class PassiveSkillParser(BasePassiveSkillParser):
             # Handle stats
             stat_modes = (
                 {
-                    "id": "stat%s_id",
-                    "value": "stat%s_value",
-                    "text": "stat_text",
                     "stats_key": "Stats",
                     "stat_value_key": "Stat%sValue",
                     "stat_buffs_key": "PassiveSkillBuffs",
                 },
                 {
-                    "id": "stat%s_id_ruthless",
-                    "value": "stat%s_value_ruthless",
-                    "text": "stat_text_ruthless",
+                    "pre": "ruthless_",
                     "stats_key": "StatsHardmode",
                     "stat_value_key": "Stat%sValueHardmode",
                     "stat_buffs_key": "BuffsHardmode",
                 },
             )
             for mode in stat_modes:
+                prefix = mode.get("pre") or ""
+                keys = {
+                    "id": f"{prefix}stat%s_id",
+                    "value": f"{prefix}stat%s_value",
+                    "text": f"{prefix}stat_text",
+                }
                 stat_ids = []
                 values = []
                 j = 0
@@ -479,11 +480,11 @@ class PassiveSkillParser(BasePassiveSkillParser):
                         break
                     j = i + 1
                     stat_ids.append(stat["Id"])
-                    infobox[mode["id"] % j] = stat["Id"]
+                    infobox[keys["id"] % j] = stat["Id"]
                     values.append(passive[mode["stat_value_key"] % j])
-                    infobox[mode["value"] % j] = passive[mode["stat_value_key"] % j]
+                    infobox[keys["value"] % j] = passive[mode["stat_value_key"] % j]
 
-                infobox[mode["text"]] = "<br>".join(
+                infobox[keys["text"]] = "<br>".join(
                     self._get_stats(
                         stat_ids, values, translation_file=get_translation_file(passive["Id"])
                     )
@@ -501,8 +502,8 @@ class PassiveSkillParser(BasePassiveSkillParser):
 
                     for i, (sid, val) in enumerate(zip(stat_ids, values)):
                         j += 1
-                        infobox[mode["id"] % j] = sid
-                        infobox[mode["value"] % j] = val
+                        infobox[keys["id"] % j] = sid
+                        infobox[keys["value"] % j] = val
 
                     text = "<br>".join(
                         self._get_stats(
@@ -520,13 +521,13 @@ class PassiveSkillParser(BasePassiveSkillParser):
                             text,
                         )
 
-                    if infobox[mode["text"]]:
-                        infobox[mode["text"]] += "<br>" + text
+                    if infobox[keys["text"]]:
+                        infobox[keys["text"]] += "<br>" + text
                     else:
-                        infobox[mode["text"]] = text
+                        infobox[keys["text"]] = text
 
-                if infobox[mode["text"]] == "":
-                    infobox.pop(mode["text"])
+                if infobox[keys["text"]] == "":
+                    infobox.pop(keys["text"])
 
             # Handle connections
             tree_count = 0

--- a/PyPoE/poe/file/specification/data/generated.py
+++ b/PyPoE/poe/file/specification/data/generated.py
@@ -2716,54 +2716,27 @@ specification = Specification(
         "AtlasNode.dat": File(
             fields=(
                 Field(
-                    name="WorldAreasKey",
-                    type="ref|out",
-                    key="WorldAreas.dat",
-                    unique=True,
+                    name="Id",
+                    type="ref|string",
                 ),
                 Field(
-                    name="ItemVisualIdentityKey",
+                    name="Area1",
                     type="ref|out",
-                    key="ItemVisualIdentity.dat",
+                    key="WorldAreas.dat",
                 ),
                 Field(
                     name="Flag0",
                     type="bool",
                 ),
                 Field(
-                    name="MapsKey",
-                    type="ref|out",
-                    key="Maps.dat",
-                ),
-                Field(
-                    name="FlavourTextKey",
+                    name="FlavourText",
                     type="ref|out",
                     key="FlavourText.dat",
                 ),
                 Field(
-                    name="AtlasNodeKeys",
+                    name="Connections",
                     type="ref|list|ref|generic",
                     key="AtlasNode.dat",
-                ),
-                Field(
-                    name="Tier0",
-                    type="int",
-                ),
-                Field(
-                    name="Tier1",
-                    type="int",
-                ),
-                Field(
-                    name="Tier2",
-                    type="int",
-                ),
-                Field(
-                    name="Tier3",
-                    type="int",
-                ),
-                Field(
-                    name="Tier4",
-                    type="int",
                 ),
                 Field(
                     name="Unknown0",
@@ -2786,7 +2759,7 @@ specification = Specification(
                     type="float",
                 ),
                 Field(
-                    name="DDSFile",
+                    name="UniqueArt",
                     type="ref|string",
                     file_path=True,
                     file_ext=".dds",
@@ -2800,8 +2773,26 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
+                    name="DivCards",
+                    type="ref|list|ref|out",
+                    key="BaseItemTypes.dat",
+                ),
+                Field(
+                    name="DivCardsHardmode",
+                    type="ref|list|ref|out",
+                    key="BaseItemTypes.dat",
+                ),
+                Field(
                     name="Unknown5",
                     type="int",
+                ),
+                Field(
+                    name="HASH16",
+                    type="short",
+                ),
+                Field(
+                    name="Flag1",
+                    type="bool",
                 ),
                 Field(
                     name="Unknown6",
@@ -2812,40 +2803,97 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
+                    name="Data0",
+                    type="ref|list|byte",
+                ),
+                Field(
+                    name="Flag2",
+                    type="bool",
+                ),
+                Field(
+                    name="Flag3",
+                    type="bool",
+                ),
+                Field(
+                    name="WatchstoneSlot",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
+                ),
+                Field(
+                    name="QuestStates",
+                    type="ref|list|int",
+                ),
+                Field(
+                    name="Flag4",
+                    type="bool",
+                ),
+                Field(
+                    name="Key1",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Area2",
+                    type="ref|out",
+                    key="WorldAreas.dat",
+                ),
+                Field(
+                    name="Flag5",
+                    type="bool",
+                ),
+                Field(
+                    name="Flag6",
+                    type="bool",
+                ),
+                Field(
                     name="Unknown8",
+                    type="float",
+                ),
+                Field(
+                    name="Flag7",
+                    type="bool",
+                ),
+                Field(
+                    name="Unknown9",
                     type="int",
                 ),
                 Field(
-                    name="DivCards",
-                    type="ref|list|ref|out",
-                    key="BaseItemTypes.dat",
+                    name="Unknown10",
+                    type="int",
                 ),
                 Field(
-                    name="Keys0",
-                    type="ref|list|ref|out",
-                    key="BaseItemTypes.dat",
+                    name="Unknown11",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown12",
+                    type="int",
+                ),
+                Field(
+                    name="Flag8",
+                    type="bool",
+                ),
+            ),
+            virtual_fields=(
+                VirtualField(
+                    name="FlavourTextKey",
+                    fields=("FlavourText",),
+                    alias=True,
                 ),
             ),
         ),
         "AtlasNodeDefinition.dat": File(
             fields=(
                 Field(
-                    name="WorldAreasKey",
+                    name="Id",
+                    type="ref|string",
+                ),
+                Field(
+                    name="Area1",
                     type="ref|out",
                     key="WorldAreas.dat",
-                ),
-                Field(
-                    name="ItemVisualIdentityKey",
-                    type="ref|out",
-                    key="ItemVisualIdentity.dat",
-                ),
-                Field(
-                    name="Flag0",
-                    type="bool",
-                ),
-                Field(
-                    name="Tier",
-                    type="int",
                 ),
                 Field(
                     name="Unknown0",
@@ -2856,8 +2904,59 @@ specification = Specification(
                     type="int",
                 ),
                 Field(
+                    name="Flag0",
+                    type="bool",
+                ),
+                Field(
                     name="Flag1",
                     type="bool",
+                ),
+                Field(
+                    name="Image",
+                    type="ref|string",
+                    file_path=True,
+                    file_ext=".dds",
+                ),
+                Field(
+                    name="Flag2",
+                    type="bool",
+                ),
+                Field(
+                    name="Flag3",
+                    type="bool",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Key1",
+                    type="ref|out",
+                ),
+                Field(
+                    name="QuestStates",
+                    type="ref|list|int",
+                ),
+                Field(
+                    name="Flag4",
+                    type="bool",
+                ),
+                Field(
+                    name="Key2",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Area2",
+                    type="ref|out",
+                    key="WorldAreas.dat",
+                ),
+                Field(
+                    name="Flag5",
+                    type="bool",
+                ),
+                Field(
+                    name="Key3",
+                    type="ref|out",
                 ),
             ),
         ),
@@ -11007,6 +11106,86 @@ specification = Specification(
                 ),
             ),
         ),
+        "FaridunLifeScalingPerLevel.dat": File(
+            fields=(
+                Field(
+                    name="Level",
+                    type="int",
+                ),
+                Field(
+                    name="Life",
+                    type="int",
+                ),
+            ),
+        ),
+        "FaridunWishFamilies.dat": File(
+            fields=(
+                Field(
+                    name="Id",
+                    type="ref|string",
+                ),
+            ),
+        ),
+        "FaridunWishes.dat": File(
+            fields=(
+                Field(
+                    name="Id",
+                    type="ref|string",
+                ),
+                Field(
+                    name="Unknown0",
+                    type="int",
+                ),
+                Field(
+                    name="Data0",
+                    type="ref|list|byte",
+                ),
+                Field(
+                    name="Icon",
+                    type="ref|string",
+                ),
+                Field(
+                    name="Key0",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Data1",
+                    type="ref|list|byte",
+                ),
+                Field(
+                    name="Key1",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Unknown1",
+                    type="int",
+                ),
+                Field(
+                    name="Unknown2",
+                    type="int",
+                ),
+                Field(
+                    name="Name",
+                    type="ref|string",
+                ),
+                Field(
+                    name="Key2",
+                    type="ref|out",
+                ),
+                Field(
+                    name="Unknown3",
+                    type="int",
+                ),
+                Field(
+                    name="Data2",
+                    type="ref|list|byte",
+                ),
+                Field(
+                    name="Unknown4",
+                    type="int",
+                ),
+            ),
+        ),
         "FixedHideoutDoodadTypes.dat": File(
             fields=(
                 Field(
@@ -15161,10 +15340,6 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Name",
-                    type="ref|string",
-                ),
-                Field(
                     name="Data0",
                     type="ref|list|int",
                 ),
@@ -15181,8 +15356,9 @@ specification = Specification(
                     type="bool",
                 ),
                 Field(
-                    name="Key0",
+                    name="UnlockMtx",
                     type="ref|out",
+                    key="MtxTypes.dat",
                 ),
                 Field(
                     name="ErrorMessage",
@@ -18689,6 +18865,10 @@ specification = Specification(
                     name="Flag6",
                     type="bool",
                 ),
+                Field(
+                    name="Keys0",
+                    type="ref|list|ref|out",
+                ),
             ),
         ),
         "MapInhabitants.dat": File(
@@ -19228,14 +19408,6 @@ specification = Specification(
                     name="AchievementItem",
                     type="ref|out",
                     key="AchievementItems.dat",
-                ),
-                Field(
-                    name="Regular_GuildCharacter",
-                    type="ref|string",
-                ),
-                Field(
-                    name="Unique_GuildCharacter",
-                    type="ref|string",
                 ),
                 Field(
                     name="Tier",
@@ -21651,6 +21823,10 @@ specification = Specification(
                     name="Keys2",
                     type="ref|list|ref|out",
                     key="GrantedEffectsPerLevel.dat",
+                ),
+                Field(
+                    name="Flag2",
+                    type="bool",
                 ),
             ),
             virtual_fields=(
@@ -24112,21 +24288,9 @@ specification = Specification(
                     type="ref|string",
                 ),
                 Field(
-                    name="Flag0",
-                    type="bool",
-                ),
-                Field(
-                    name="Flag1",
-                    type="bool",
-                ),
-                Field(
                     name="Signature_ModsKey",
                     type="ref|out",
                     key="Mods.dat",
-                ),
-                Field(
-                    name="Flag2",
-                    type="bool",
                 ),
                 Field(
                     name="SpawnWeight_TagsKeys",
@@ -24142,31 +24306,6 @@ specification = Specification(
                     type="ref|out",
                 ),
                 Field(
-                    name="Unknown0",
-                    type="int",
-                ),
-                Field(
-                    name="AreaDescription",
-                    type="ref|string",
-                ),
-                Field(
-                    name="Key1",
-                    type="ref|out",
-                ),
-                Field(
-                    name="Unknown1",
-                    type="int",
-                ),
-                Field(
-                    name="Key2",
-                    type="ref|out",
-                    key="Stats.dat",
-                ),
-                Field(
-                    name="HasAreaMissions",
-                    type="bool",
-                ),
-                Field(
                     name="Keys0",
                     type="ref|list|ref|out",
                 ),
@@ -24175,15 +24314,7 @@ specification = Specification(
                     type="ref|list|ref|out",
                 ),
                 Field(
-                    name="Key3",
-                    type="ref|out",
-                ),
-                Field(
-                    name="Keys2",
-                    type="ref|list|ref|out",
-                ),
-                Field(
-                    name="Key4",
+                    name="Key1",
                     type="ref|out",
                 ),
             ),
@@ -27176,8 +27307,8 @@ specification = Specification(
                     key="ClientStrings.dat",
                 ),
                 Field(
-                    name="Key0",
-                    type="ref|out",
+                    name="Flag0",
+                    type="bool",
                 ),
             ),
         ),
@@ -31889,12 +32020,8 @@ specification = Specification(
                     key="FlavourText.dat",
                 ),
                 Field(
-                    name="HasGuildCharacter",
+                    name="Flag0",
                     type="bool",
-                ),
-                Field(
-                    name="GuildCharacter",
-                    type="ref|string",
                 ),
                 Field(
                     name="Name",


### PR DESCRIPTION
This is a partial update for 3.28.0. The Atlas stuff will still need further attention.

- Imported updated schema for 3.28
- In passive skill exporter, changed names of template parameters for stats in Ruthless
- Fixed page name conflict for Kishara's Star quest item
- Reduced code duplication and misc code cleanup