### PR TITLE
Skill levels

### DIFF
--- a/PyPoE/cli/exporter/poe2wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/poe2wiki/parsers/skill.py
@@ -938,7 +938,7 @@ class SkillParserShared(parser.BaseParser):
             if i == 20:
                 break
             prefix = "level%s" % (i + 1)
-            infobox[prefix] = "True"
+            infobox[prefix] = row["Level"]
             prefix += "_"
 
             # Level and attribute requirements

--- a/PyPoE/cli/exporter/wiki/parsers/skill.py
+++ b/PyPoE/cli/exporter/wiki/parsers/skill.py
@@ -973,7 +973,7 @@ class SkillParserShared(parser.BaseParser):
         # Body
         for i, row in enumerate(level_data):
             prefix = "level%s" % (i + 1)
-            infobox[prefix] = "True"
+            infobox[prefix] = row["Level"]
 
             # In 3.21 the level requirement is a float so we need to cast it to int
             if "PlayerLevelReq" in row and row["PlayerLevelReq"] == int(row["PlayerLevelReq"]):


### PR DESCRIPTION
This is a small change to the skills exporter which gives us the actual skill level numbers, since not all skills have levels which start at 1. This can potentially be used to solve the issue where the skill level progression template displays the wrong skill levels.